### PR TITLE
feat(api): add production health-only safety boundary

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,7 @@ node_modules
 !**/.env.example
 tests
 docs
+deploy
 *.md
 .gcloudignore
 .dockerignore

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -6,6 +6,7 @@ venv
 frontend
 logs
 docs
+deploy
 *.md
 node_modules
 **/__pycache__

--- a/README.md
+++ b/README.md
@@ -116,8 +116,11 @@ Backend (optional):
 | Variable | Purpose |
 | --- | --- |
 | `CORS_ALLOW_ORIGINS` | Comma-separated explicit browser origins. Default includes local Vite and `https://sportbeacon-ai.vercel.app`. Do not set `*`. |
-| `CORS_ALLOW_ORIGIN_REGEX` | Optional override. Default allows SportBeacon Vercel git preview hosts only. |
+| `CORS_ALLOW_ORIGIN_REGEX` | Optional override. Default allows SportBeacon Vercel git preview hosts only. Production sets `^$` so preview hosts are not echoed. |
 | `ENABLE_EXPERIMENTAL_ROUTES` | Defaults to `false`. Coach, highlight, and extended-schedule routes return 404 until explicitly enabled. |
+| `ENABLE_PRODUCT_ROUTES` | Defaults on outside production. Production ignores this until authenticated product APIs exist and stays health-only. |
+| `ENABLE_API_DOCS` | Defaults on outside production. Disabled when `APP_ENV=production`. |
+| `APP_ENV` | Set `production` only on the production Cloud Run service. |
 
 Do not put production URLs, Firebase keys, cloud tokens, or other credentials in the frontend shell. Root `env.example` still documents historical product placeholders; those services are not wired into this Phase 1 app.
 
@@ -142,17 +145,19 @@ Required Vercel project settings:
 | Build Command | `npm run build` |
 | Output Directory | `dist` |
 
-This Vercel project deploys only the Vite frontend. FastAPI staging is a separate Cloud Run service:
+This Vercel project deploys only the Vite frontend. FastAPI runs on separate Cloud Run services:
 
 - Google Cloud project: `sportbeacon-ai` (number `104921686559`)
 - Region: `us-east1`
-- Service: `sportbeacon-api-staging`
-- Runtime identity: `sportbeacon-api-runtime@sportbeacon-ai.iam.gserviceaccount.com`
+- Staging service: `sportbeacon-api-staging`
+- Staging runtime identity: `sportbeacon-api-runtime@sportbeacon-ai.iam.gserviceaccount.com`
 - Staging URL: `https://sportbeacon-api-staging-104921686559.us-east1.run.app`
+- Production service: `sportbeacon-api`
+- Production runtime identity: `sportbeacon-api-prod-runtime@sportbeacon-ai.iam.gserviceaccount.com`
 
-See `docs/cloud-run-deployment.md` to recreate the staging service.
+See `docs/cloud-run-deployment.md` to recreate staging or production. Production is health-only until authenticated product APIs exist.
 
-Vercel Preview may set `VITE_API_BASE_URL` to that staging HTTPS origin so the preview shell can show **Connected**. Do not set Production `VITE_API_BASE_URL` until the staging API is accepted. Local development still uses `http://127.0.0.1:8000`.
+Vercel Preview may set `VITE_API_BASE_URL` to the staging HTTPS origin. Vercel Production must use the production Cloud Run origin, never staging. Local development still uses `http://127.0.0.1:8000`.
 
 ## License
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,6 +14,9 @@ CORS_ALLOW_ORIGIN_REGEX=^https://sportbeacon-ai-git-[a-z0-9-]+-trondurells-proje
 
 # Incomplete coach, highlight, and extended-schedule routes stay off unless explicitly enabled.
 ENABLE_EXPERIMENTAL_ROUTES=false
+ENABLE_PRODUCT_ROUTES=true
+ENABLE_API_DOCS=true
+APP_ENV=development
 
 # Legacy Express / WebSocket configuration (not used by the FastAPI shell)
 CLIENT_ORIGIN=http://localhost:3000

--- a/backend/api.py
+++ b/backend/api.py
@@ -1,5 +1,8 @@
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import APIRouter, FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 from typing import Any, Dict, List, Optional
 from .models import (
     API_VERSION,
@@ -38,12 +41,54 @@ VERCEL_PREVIEW_ORIGIN_REGEX = (
     r"^https://sportbeacon-ai-git-[a-z0-9-]+-trondurells-projects\.vercel\.app$"
 )
 EXPERIMENTAL_ROUTE_DETAIL = "This experimental route is disabled"
+PRODUCT_ROUTE_DETAIL = "Not Found"
+HEALTH_PATH = "/api/health"
+HEALTH_METHODS = {"GET", "HEAD", "OPTIONS"}
+TRUE_VALUES = {"1", "true", "yes", "on"}
+FALSE_VALUES = {"0", "false", "no", "off"}
+
+
+def _env_flag(name: str) -> Optional[bool]:
+    raw = os.getenv(name)
+    if raw is None or not str(raw).strip():
+        return None
+    value = str(raw).strip().lower()
+    if value in TRUE_VALUES:
+        return True
+    if value in FALSE_VALUES:
+        return False
+    return None
+
+
+def is_production() -> bool:
+    return os.getenv("APP_ENV", "").strip().lower() == "production"
+
+
+def authenticated_product_apis_enabled() -> bool:
+    """Authenticated product APIs are not implemented yet. Always fail closed."""
+    return False
+
+
+def product_routes_enabled() -> bool:
+    """Production stays health-only until authenticated product APIs exist."""
+    if is_production() and not authenticated_product_apis_enabled():
+        return False
+    return _env_flag("ENABLE_PRODUCT_ROUTES") is not False
+
+
+def api_docs_enabled() -> bool:
+    if is_production():
+        return False
+    flag = _env_flag("ENABLE_API_DOCS")
+    return flag is not False
 
 
 def cors_allow_origins() -> List[str]:
     """Explicit origins only; never '*'."""
     raw = os.getenv("CORS_ALLOW_ORIGINS", "")
     if not raw.strip():
+        if is_production():
+            return [PRODUCTION_ORIGIN]
         return list(DEFAULT_CORS_ORIGINS)
     origins = [item.strip() for item in raw.split(",") if item.strip()]
     if "*" in origins:
@@ -51,18 +96,23 @@ def cors_allow_origins() -> List[str]:
     return origins
 
 
-def cors_allow_origin_regex() -> str:
-    raw = os.getenv("CORS_ALLOW_ORIGIN_REGEX", "").strip()
-    return raw or VERCEL_PREVIEW_ORIGIN_REGEX
+def cors_allow_origin_regex() -> Optional[str]:
+    raw = os.getenv("CORS_ALLOW_ORIGIN_REGEX")
+    if raw is not None:
+        stripped = raw.strip()
+        if stripped in {"", "^$"}:
+            return None
+        return stripped
+    if is_production():
+        return None
+    return VERCEL_PREVIEW_ORIGIN_REGEX
 
 
 def experimental_routes_enabled() -> bool:
-    return os.getenv("ENABLE_EXPERIMENTAL_ROUTES", "false").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-        "on",
-    }
+    flag = _env_flag("ENABLE_EXPERIMENTAL_ROUTES")
+    if flag is True:
+        return True
+    return False
 
 
 def require_experimental_routes() -> None:
@@ -70,15 +120,19 @@ def require_experimental_routes() -> None:
         raise HTTPException(status_code=404, detail=EXPERIMENTAL_ROUTE_DETAIL)
 
 
-app = FastAPI(title="SportBeacon AI API", version=API_VERSION)
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=cors_allow_origins(),
-    allow_origin_regex=cors_allow_origin_regex(),
-    allow_credentials=True,
-    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-    allow_headers=["Content-Type", "Authorization"],
-)
+class ProductionRouteGateMiddleware(BaseHTTPMiddleware):
+    """Allowlist-only gate. Missing production config fails closed, not open."""
+
+    async def dispatch(self, request: Request, call_next):
+        if product_routes_enabled():
+            return await call_next(request)
+        path = request.url.path.rstrip("/") or "/"
+        if path == HEALTH_PATH and request.method.upper() in HEALTH_METHODS:
+            return await call_next(request)
+        return JSONResponse({"detail": PRODUCT_ROUTE_DETAIL}, status_code=404)
+
+
+router = APIRouter()
 insight_service = PlayerInsightService()
 matchmaking_service = MatchmakingService()
 drill_service = DrillService()
@@ -102,7 +156,7 @@ def _get_coach_assistant():
         _coach_assistant = CoachAssistant(os.getenv("OPENAI_API_KEY"))
     return _coach_assistant
 
-@app.get("/api/health", response_model=HealthResponse)
+@router.get("/api/health", response_model=HealthResponse)
 async def health() -> HealthResponse:
     """Canonical liveness check used by the Vite shell."""
     return HealthResponse(
@@ -112,7 +166,7 @@ async def health() -> HealthResponse:
     )
 
 
-@app.get("/api/players/top-winners", response_model=List[PlayerInsightResponse])
+@router.get("/api/players/top-winners", response_model=List[PlayerInsightResponse])
 async def get_top_winners(time_period_days: int = 30, limit: int = 5):
     """
     Get the top players with highest win rates for the specified time period.
@@ -132,7 +186,7 @@ async def get_top_winners(time_period_days: int = 30, limit: int = 5):
             detail=f"Error calculating top winners: {str(e)}"
         )
 
-@app.post("/api/players/analyze", response_model=PlayerAnalysisResponse)
+@router.post("/api/players/analyze", response_model=PlayerAnalysisResponse)
 async def analyze_player_stats(stats: List[PlayerStatRecord]):
     """
     Analyze player statistics to generate insights.
@@ -158,7 +212,7 @@ async def analyze_player_stats(stats: List[PlayerStatRecord]):
             detail=f"Error analyzing player stats: {str(e)}"
         )
 
-@app.post("/api/matchmaking/create-teams", response_model=MatchmakingResponse)
+@router.post("/api/matchmaking/create-teams", response_model=MatchmakingResponse)
 async def create_balanced_teams(request: MatchmakingRequest):
     """
     Create balanced teams from player statistics.
@@ -179,7 +233,7 @@ async def create_balanced_teams(request: MatchmakingRequest):
             detail=f"Error creating balanced teams: {str(e)}"
         )
 
-@app.post("/api/drills/recommend")
+@router.post("/api/drills/recommend")
 async def get_drill_recommendations(
     request: DrillRecommendationRequest
 ) -> DrillRecommendationResponse:
@@ -191,7 +245,7 @@ async def get_drill_recommendations(
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-@app.post("/api/drills/recommend/formatted")
+@router.post("/api/drills/recommend/formatted")
 async def get_formatted_recommendations(
     request: DrillRecommendationRequest,
     format_type: str = 'text'
@@ -203,7 +257,7 @@ async def get_formatted_recommendations(
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-@app.post("/api/drills/schedule")
+@router.post("/api/drills/schedule")
 async def get_weekly_schedule(
     request: DrillScheduleRequest
 ) -> DrillScheduleResponse:
@@ -215,7 +269,7 @@ async def get_weekly_schedule(
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-@app.post("/api/drills/schedule/formatted")
+@router.post("/api/drills/schedule/formatted")
 async def get_formatted_schedule(
     request: DrillScheduleRequest,
     format_type: str = 'text'
@@ -227,7 +281,7 @@ async def get_formatted_schedule(
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-@app.post("/api/highlights/tag")
+@router.post("/api/highlights/tag")
 async def tag_game_highlights(
     game_id: str,
     events: List[Dict]
@@ -242,7 +296,7 @@ async def tag_game_highlights(
             detail=f"Error processing highlights: {str(e)}"
         )
 
-@app.post("/api/coach/ask")
+@router.post("/api/coach/ask")
 async def ask_coach_question(
     request: CoachQuestion,
     channel: str = Query(default="chat", pattern="^(chat|email|sms|web)$")
@@ -257,7 +311,7 @@ async def ask_coach_question(
             detail=f"Error processing coaching question: {str(e)}"
         )
 
-@app.get("/api/coach/weekly-summary/{player_id}")
+@router.get("/api/coach/weekly-summary/{player_id}")
 async def get_weekly_summary(
     player_id: str,
     channel: str = Query(default="chat", pattern="^(chat|email|sms|web)$")
@@ -278,7 +332,7 @@ async def get_weekly_summary(
             detail=f"Error generating weekly summary: {str(e)}"
         )
 
-@app.post("/api/drills/schedule/extended")
+@router.post("/api/drills/schedule/extended")
 async def get_extended_schedule(
     request: ExtendedDrillScheduleRequest
 ) -> DrillScheduleResponse:
@@ -288,6 +342,31 @@ async def get_extended_schedule(
         return drill_service.get_extended_schedule(request)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+
+def create_app() -> FastAPI:
+    docs_enabled = api_docs_enabled()
+    application = FastAPI(
+        title="SportBeacon AI API",
+        version=API_VERSION,
+        docs_url="/docs" if docs_enabled else None,
+        redoc_url="/redoc" if docs_enabled else None,
+        openapi_url="/openapi.json" if docs_enabled else None,
+    )
+    application.add_middleware(ProductionRouteGateMiddleware)
+    application.add_middleware(
+        CORSMiddleware,
+        allow_origins=cors_allow_origins(),
+        allow_origin_regex=cors_allow_origin_regex(),
+        allow_credentials=True,
+        allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+        allow_headers=["Content-Type", "Authorization"],
+    )
+    application.include_router(router)
+    return application
+
+
+app = create_app()
 
 # Sample test data for the analyze endpoint
 SAMPLE_ANALYZE_PAYLOAD = [

--- a/deploy/cloud-run-production.env.example
+++ b/deploy/cloud-run-production.env.example
@@ -1,0 +1,6 @@
+APP_ENV=production
+ENABLE_PRODUCT_ROUTES=false
+ENABLE_EXPERIMENTAL_ROUTES=false
+ENABLE_API_DOCS=false
+CORS_ALLOW_ORIGINS=https://sportbeacon-ai.vercel.app
+CORS_ALLOW_ORIGIN_REGEX=^$

--- a/docs/cloud-run-deployment.md
+++ b/docs/cloud-run-deployment.md
@@ -1,19 +1,58 @@
-# Cloud Run staging deployment
+# Cloud Run FastAPI deployment
 
-Recreate the SportBeacon FastAPI **staging** service from this repository. This is not a production runbook.
+Recreate the SportBeacon FastAPI **staging** and **production** services from this repository. Staging and production must remain separate Cloud Run services with separate runtime identities. Do not point Vercel Production at staging.
 
-## Target
+## Shared target
 
 | Item | Value |
 | --- | --- |
 | Google Cloud project ID | `sportbeacon-ai` |
 | Project number | `104921686559` |
 | Region | `us-east1` |
+
+## Staging
+
+| Item | Value |
+| --- | --- |
 | Service | `sportbeacon-api-staging` |
 | Runtime identity | `sportbeacon-api-runtime@sportbeacon-ai.iam.gserviceaccount.com` |
 | Staging URL | `https://sportbeacon-api-staging-104921686559.us-east1.run.app` |
 
-Production traffic must use a **separate** Cloud Run service later. Do not point Vercel Production at this staging service.
+Staging may keep local/dev product routes available for preview testing. Experimental coach, highlight, and extended-schedule routes stay disabled.
+
+## Production
+
+| Item | Value |
+| --- | --- |
+| Service | `sportbeacon-api` |
+| Runtime identity | `sportbeacon-api-prod-runtime@sportbeacon-ai.iam.gserviceaccount.com` |
+| Expected URL | `https://sportbeacon-api-104921686559.us-east1.run.app` |
+
+Confirm the live URL with `gcloud run services describe` after deploy. Do not assume a URL until Cloud Run reports Ready.
+
+### Production security boundary
+
+When `APP_ENV=production`, the service is **health-only**:
+
+- `GET /api/health` remains public and returns HTTP 200.
+- CORS preflight for `/api/health` is allowed from `https://sportbeacon-ai.vercel.app` only.
+- All other API routes return 404, including insights, drills, matchmaking, coach, highlight, media, and extended-schedule paths.
+- `/docs`, `/redoc`, and `/openapi.json` are disabled.
+- Vercel preview origins are not echoed.
+- Unrelated origins are not echoed.
+- `ENABLE_PRODUCT_ROUTES=true` does not open unauthenticated product APIs. Authenticated product APIs are not implemented yet, so production stays fail closed.
+- `ENABLE_EXPERIMENTAL_ROUTES` remains `false`.
+
+Non-secret production environment (also in `deploy/cloud-run-production.env.example`):
+
+```text
+APP_ENV=production
+ENABLE_PRODUCT_ROUTES=false
+ENABLE_EXPERIMENTAL_ROUTES=false
+ENABLE_API_DOCS=false
+CORS_ALLOW_ORIGINS=https://sportbeacon-ai.vercel.app
+CORS_ALLOW_ORIGIN_REGEX=^$
+```
 
 ## Required APIs
 
@@ -24,28 +63,37 @@ gcloud config set project sportbeacon-ai
 gcloud services enable run.googleapis.com cloudbuild.googleapis.com artifactregistry.googleapis.com
 ```
 
-## Runtime identity
+## Runtime identities
 
-Use a dedicated **keyless** service account for Cloud Run. Do not reuse the default Compute Engine account, Firebase Admin, or Firebase Automations.
+Use dedicated **keyless** service accounts. Do not reuse the default Compute Engine account, App Engine default, Firebase Admin, or Firebase Automations. Do not grant Owner or Editor. Do not grant Firebase or Firestore roles for this health-only API.
 
 ```powershell
 gcloud iam service-accounts describe sportbeacon-api-runtime@sportbeacon-ai.iam.gserviceaccount.com
+gcloud iam service-accounts describe sportbeacon-api-prod-runtime@sportbeacon-ai.iam.gserviceaccount.com
 ```
 
-If it does not exist:
+If a dedicated account does not exist:
 
 ```powershell
 gcloud iam service-accounts create sportbeacon-api-runtime `
-  --display-name="SportBeacon API Cloud Run runtime" `
-  --description="Keyless runtime identity for the SportBeacon FastAPI service"
+  --display-name="SportBeacon API Cloud Run staging runtime" `
+  --description="Keyless runtime identity for the SportBeacon FastAPI staging service"
+
+gcloud iam service-accounts create sportbeacon-api-prod-runtime `
+  --display-name="SportBeacon API Cloud Run production runtime" `
+  --description="Keyless runtime identity for the SportBeacon FastAPI production service"
 ```
 
-Do **not** create, download, or commit a JSON service-account key. Cloud Run impersonates this account without a key file. Phase 2A does not need extra project roles on this identity.
+Do **not** create, download, or commit a JSON service-account key. Cloud Run impersonates these accounts without a key file. The health-only production service currently needs no application-level Google Cloud roles.
 
-Allow the Cloud Run service agent to use the runtime account (IAM on this new account only):
+Allow the Cloud Run service agent to use each runtime account (IAM on the new accounts only):
 
 ```powershell
 gcloud iam service-accounts add-iam-policy-binding sportbeacon-api-runtime@sportbeacon-ai.iam.gserviceaccount.com `
+  --member="serviceAccount:service-104921686559@serverless-robot-prod.iam.gserviceaccount.com" `
+  --role="roles/iam.serviceAccountUser"
+
+gcloud iam service-accounts add-iam-policy-binding sportbeacon-api-prod-runtime@sportbeacon-ai.iam.gserviceaccount.com `
   --member="serviceAccount:service-104921686559@serverless-robot-prod.iam.gserviceaccount.com" `
   --role="roles/iam.serviceAccountUser"
 ```
@@ -53,6 +101,18 @@ gcloud iam service-accounts add-iam-policy-binding sportbeacon-api-runtime@sport
 ## Source build and deploy
 
 From the repository root. The `Dockerfile` listens on `$PORT` (Cloud Run default `8080`).
+
+| Setting | Value |
+| --- | --- |
+| CPU | 1 |
+| Memory | 1 GiB |
+| Minimum instances | 0 |
+| Maximum instances | 2 |
+| Container port | `$PORT` (8080) |
+
+`.dockerignore` and `.gcloudignore` keep frontend, docs, deploy templates, tests, local env files, and Git metadata out of the image.
+
+### Staging
 
 ```powershell
 gcloud run deploy sportbeacon-api-staging `
@@ -69,54 +129,87 @@ gcloud run deploy sportbeacon-api-staging `
   --set-env-vars "CORS_ALLOW_ORIGINS=https://sportbeacon-ai.vercel.app,ENABLE_EXPERIMENTAL_ROUTES=false"
 ```
 
-| Setting | Value |
-| --- | --- |
-| CPU | 1 |
-| Memory | 1 GiB |
-| Minimum instances | 0 |
-| Maximum instances | 2 |
-| Container port | `$PORT` (8080) |
-
-`.dockerignore` and `.gcloudignore` keep frontend, docs, tests, local env files, and Git metadata out of the image.
-
-## Non-secret environment variables
-
-| Variable | Staging value |
-| --- | --- |
-| `CORS_ALLOW_ORIGINS` | `https://sportbeacon-ai.vercel.app` |
-| `ENABLE_EXPERIMENTAL_ROUTES` | `false` |
-
 Preview CORS is the code default regex for SportBeacon Vercel git hosts:
 
 ```text
 ^https://sportbeacon-ai-git-[a-z0-9-]+-trondurells-projects\.vercel\.app$
 ```
 
-Do not set `CORS_ALLOW_ORIGINS=*`. Do not put secrets, Firebase config, or API keys in Cloud Run env for this service.
+### Production
 
-## Health check
+Deploy from a clean checkout of the merged `main` SHA that contains the health-only safety boundary.
+
+```powershell
+gcloud run deploy sportbeacon-api `
+  --source . `
+  --project sportbeacon-ai `
+  --region us-east1 `
+  --service-account sportbeacon-api-prod-runtime@sportbeacon-ai.iam.gserviceaccount.com `
+  --allow-unauthenticated `
+  --min-instances 0 `
+  --max-instances 2 `
+  --cpu 1 `
+  --memory 1Gi `
+  --port 8080 `
+  --set-env-vars "APP_ENV=production,ENABLE_PRODUCT_ROUTES=false,ENABLE_EXPERIMENTAL_ROUTES=false,ENABLE_API_DOCS=false,CORS_ALLOW_ORIGINS=https://sportbeacon-ai.vercel.app,CORS_ALLOW_ORIGIN_REGEX=^$"
+```
+
+Do not set `CORS_ALLOW_ORIGINS=*`. Do not put secrets, Firebase config, or API keys in Cloud Run env for these services.
+
+## Health and route-gate verification
+
+### Staging
 
 ```powershell
 curl.exe -i https://sportbeacon-api-staging-104921686559.us-east1.run.app/api/health
-```
-
-Expect HTTP 200 and JSON with `status`, `service`, and `version`.
-
-Allowed-origin checks:
-
-```powershell
 curl.exe -i -H "Origin: https://sportbeacon-ai.vercel.app" https://sportbeacon-api-staging-104921686559.us-east1.run.app/api/health
 curl.exe -i -H "Origin: https://evil.example" https://sportbeacon-api-staging-104921686559.us-east1.run.app/api/health
 ```
 
-The production origin must receive `access-control-allow-origin`. An unrelated origin must not be echoed.
+Expect HTTP 200 JSON with `status`, `service`, and `version`. The production origin must receive `access-control-allow-origin`. An unrelated origin must not be echoed.
+
+### Production
+
+Replace the URL with the verified production origin:
+
+```powershell
+curl.exe -i https://sportbeacon-api-104921686559.us-east1.run.app/api/health
+curl.exe -i https://sportbeacon-api-104921686559.us-east1.run.app/docs
+curl.exe -i https://sportbeacon-api-104921686559.us-east1.run.app/openapi.json
+curl.exe -i -X POST https://sportbeacon-api-104921686559.us-east1.run.app/api/insights/analyze -H "Content-Type: application/json" -d "[{\"player_id\":1,\"player_name\":\"A\",\"game_date\":\"2024-04-01T20:00:00\",\"points\":18,\"assists\":5,\"rebounds\":6,\"steals\":1,\"blocks\":1,\"field_goal_percentage\":48,\"three_point_percentage\":35,\"result\":\"win\"}]"
+curl.exe -i -X POST https://sportbeacon-api-104921686559.us-east1.run.app/api/drills/recommend -H "Content-Type: application/json" -d "{\"user_id\":\"player-1\",\"skill_levels\":{\"shooting\":0.4},\"growth_areas\":[\"shooting\"],\"top_skills\":[\"defense\"],\"min_difficulty\":\"Beginner\",\"max_difficulty\":\"Advanced\"}"
+curl.exe -i -X POST https://sportbeacon-api-104921686559.us-east1.run.app/api/matchmaking/balance -H "Content-Type: application/json" -d "{\"team_size\":3,\"consider_positions\":true,\"players\":[]}"
+curl.exe -i -H "Origin: https://sportbeacon-ai.vercel.app" https://sportbeacon-api-104921686559.us-east1.run.app/api/health
+curl.exe -i -H "Origin: https://sportbeacon-ai-git-feat-cloud-run-f-ddbf56-trondurells-projects.vercel.app" https://sportbeacon-api-104921686559.us-east1.run.app/api/health
+curl.exe -i -H "Origin: https://evil.example" https://sportbeacon-api-104921686559.us-east1.run.app/api/health
+```
+
+Expect `/api/health` HTTP 200, documentation and product routes HTTP 404, production origin CORS echoed, preview and unrelated origins not echoed.
+
+## Vercel Production environment
+
+Preview `VITE_API_BASE_URL` must continue to use the staging Cloud Run origin. Production must use the production Cloud Run origin only.
+
+1. Inspect Production `VITE_API_BASE_URL` without printing other environment values.
+2. Stop if it already contains an unexpected non-local URL.
+3. Set Production only: `VITE_API_BASE_URL=<verified sportbeacon-api origin>`.
+4. Do not change Preview or Development values.
+5. Redeploy Production from the exact merged `main` SHA through Git integration. Do not deploy a dirty local worktree.
 
 ## Describe and rollback
 
 ```powershell
 gcloud run services describe sportbeacon-api-staging --project sportbeacon-ai --region us-east1
-gcloud run revisions list --service sportbeacon-api-staging --project sportbeacon-ai --region us-east1
-gcloud run services update-traffic sportbeacon-api-staging --to-revisions REVISION=100 --project sportbeacon-ai --region us-east1
+gcloud run services describe sportbeacon-api --project sportbeacon-ai --region us-east1
+gcloud run revisions list --service sportbeacon-api --project sportbeacon-ai --region us-east1
+gcloud run services update-traffic sportbeacon-api --to-revisions REVISION=100 --project sportbeacon-ai --region us-east1
 ```
 
-Replace `REVISION` with a previous ready revision name. Do not roll staging traffic onto a production service that does not exist yet.
+Replace `REVISION` with a previous ready revision name.
+
+If Vercel Production fails after connecting the API:
+
+- Restore the previous Production `VITE_API_BASE_URL` value (absent/local fallback).
+- Roll back to the prior known-good Vercel production deployment.
+- Leave Cloud Run available for diagnosis.
+- Do not point production at staging.

--- a/tests/test_production_api_safety.py
+++ b/tests/test_production_api_safety.py
@@ -1,0 +1,206 @@
+from typing import Optional
+
+from fastapi.testclient import TestClient
+
+from backend.api import create_app
+from backend.models import API_VERSION, SERVICE_NAME
+
+
+PROD_ORIGIN = "https://sportbeacon-ai.vercel.app"
+PREVIEW_ORIGIN = (
+    "https://sportbeacon-ai-git-feat-cloud-run-f-ddbf56-trondurells-projects.vercel.app"
+)
+UNRELATED_ORIGIN = "https://evil.example"
+
+INSIGHT_PAYLOAD = [
+    {
+        "player_id": 1,
+        "player_name": "John Smith",
+        "game_date": "2024-04-01T20:00:00",
+        "points": 18,
+        "assists": 5,
+        "rebounds": 6,
+        "steals": 1,
+        "blocks": 1,
+        "field_goal_percentage": 48.0,
+        "three_point_percentage": 35.0,
+        "result": "win",
+    }
+]
+
+DRILL_PAYLOAD = {
+    "user_id": "player-1",
+    "skill_levels": {"shooting": 0.4, "defense": 0.6},
+    "growth_areas": ["shooting"],
+    "top_skills": ["defense"],
+    "max_recommendations": 3,
+    "min_difficulty": "Beginner",
+    "max_difficulty": "Advanced",
+}
+
+MATCHMAKING_PAYLOAD = {
+    "team_size": 3,
+    "consider_positions": True,
+    "players": [
+        {
+            "player_id": idx,
+            "player_name": name,
+            "game_date": f"2024-04-0{idx}T20:00:00",
+            "points": 20 + idx,
+            "assists": 5,
+            "rebounds": 6,
+            "steals": 1,
+            "blocks": 1,
+            "field_goal_percentage": 48.0,
+            "three_point_percentage": 35.0,
+            "result": "win",
+        }
+        for idx, name in enumerate(["A", "B", "C", "D", "E", "F"], start=1)
+    ],
+}
+
+
+def _production_client(monkeypatch, extra: Optional[dict] = None) -> TestClient:
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("ENABLE_PRODUCT_ROUTES", "false")
+    monkeypatch.setenv("ENABLE_EXPERIMENTAL_ROUTES", "false")
+    monkeypatch.setenv("ENABLE_API_DOCS", "false")
+    monkeypatch.setenv("CORS_ALLOW_ORIGINS", PROD_ORIGIN)
+    monkeypatch.setenv("CORS_ALLOW_ORIGIN_REGEX", "^$")
+    for key, value in (extra or {}).items():
+        if value is None:
+            monkeypatch.delenv(key, raising=False)
+        else:
+            monkeypatch.setenv(key, value)
+    return TestClient(create_app())
+
+
+def test_production_health_returns_200(monkeypatch):
+    client = _production_client(monkeypatch)
+    response = client.get("/api/health")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body["service"] == SERVICE_NAME
+    assert body["version"] == API_VERSION
+
+
+def test_production_health_cors_allows_production_origin(monkeypatch):
+    client = _production_client(monkeypatch)
+    response = client.get("/api/health", headers={"Origin": PROD_ORIGIN})
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") == PROD_ORIGIN
+
+
+def test_production_health_preflight_allows_production_origin(monkeypatch):
+    client = _production_client(monkeypatch)
+    response = client.options(
+        "/api/health",
+        headers={
+            "Origin": PROD_ORIGIN,
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert response.status_code in {200, 204}
+    assert response.headers.get("access-control-allow-origin") == PROD_ORIGIN
+
+
+def test_production_rejects_vercel_preview_origin(monkeypatch):
+    client = _production_client(monkeypatch)
+    response = client.get("/api/health", headers={"Origin": PREVIEW_ORIGIN})
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") != PREVIEW_ORIGIN
+
+
+def test_production_rejects_unrelated_origin(monkeypatch):
+    client = _production_client(monkeypatch)
+    response = client.get("/api/health", headers={"Origin": UNRELATED_ORIGIN})
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") != UNRELATED_ORIGIN
+
+
+def test_production_insights_return_404(monkeypatch):
+    client = _production_client(monkeypatch)
+    for path in ("/api/insights/analyze", "/api/players/analyze"):
+        response = client.post(path, json=INSIGHT_PAYLOAD)
+        assert response.status_code == 404, response.text
+
+
+def test_production_drill_recommendations_return_404(monkeypatch):
+    client = _production_client(monkeypatch)
+    response = client.post("/api/drills/recommend", json=DRILL_PAYLOAD)
+    assert response.status_code == 404, response.text
+
+
+def test_production_matchmaking_returns_404(monkeypatch):
+    client = _production_client(monkeypatch)
+    for path in ("/api/matchmaking/balance", "/api/matchmaking/create-teams"):
+        response = client.post(path, json=MATCHMAKING_PAYLOAD)
+        assert response.status_code == 404, response.text
+
+
+def test_production_experimental_endpoints_return_404(monkeypatch):
+    client = _production_client(monkeypatch)
+    highlight = client.post("/api/highlights/tag?game_id=g1", json=[])
+    coach = client.post(
+        "/api/coach/ask",
+        json={
+            "user_id": "u1",
+            "question": "How do I shoot?",
+            "include_stats": False,
+            "context": None,
+        },
+    )
+    media = client.post("/api/media/upload", json={"uri": "gs://example/object"})
+    for response in (highlight, coach, media):
+        assert response.status_code == 404, response.text
+
+
+def test_production_api_documentation_endpoints_return_404(monkeypatch):
+    client = _production_client(monkeypatch)
+    for path in ("/docs", "/redoc", "/openapi.json"):
+        response = client.get(path)
+        assert response.status_code == 404, response.text
+
+
+def test_production_missing_configuration_fails_closed(monkeypatch):
+    client = _production_client(
+        monkeypatch,
+        extra={
+            "ENABLE_PRODUCT_ROUTES": None,
+            "ENABLE_EXPERIMENTAL_ROUTES": None,
+            "ENABLE_API_DOCS": None,
+            "CORS_ALLOW_ORIGINS": None,
+            "CORS_ALLOW_ORIGIN_REGEX": None,
+        },
+    )
+    assert client.get("/api/health").status_code == 200
+    assert client.post("/api/drills/recommend", json=DRILL_PAYLOAD).status_code == 404
+    assert client.get("/docs").status_code == 404
+    preview = client.get("/api/health", headers={"Origin": PREVIEW_ORIGIN})
+    assert preview.headers.get("access-control-allow-origin") != PREVIEW_ORIGIN
+    allowed = client.get("/api/health", headers={"Origin": PROD_ORIGIN})
+    assert allowed.headers.get("access-control-allow-origin") == PROD_ORIGIN
+
+
+def test_production_ignores_product_route_flag_without_auth(monkeypatch):
+    client = _production_client(
+        monkeypatch,
+        extra={"ENABLE_PRODUCT_ROUTES": "true", "ENABLE_API_DOCS": "true"},
+    )
+    assert client.post("/api/drills/recommend", json=DRILL_PAYLOAD).status_code == 404
+    assert client.get("/docs").status_code == 404
+
+
+def test_non_production_product_routes_remain_available():
+    client = TestClient(create_app())
+    drills = client.post("/api/drills/recommend", json=DRILL_PAYLOAD)
+    insights = client.post("/api/players/analyze", json=INSIGHT_PAYLOAD)
+    matchmaking = client.post("/api/matchmaking/create-teams", json=MATCHMAKING_PAYLOAD)
+    assert drills.status_code == 200, drills.text
+    assert insights.status_code == 200, insights.text
+    assert matchmaking.status_code == 200, matchmaking.text
+    docs = client.get("/openapi.json")
+    assert docs.status_code == 200
+    preview = client.get("/api/health", headers={"Origin": PREVIEW_ORIGIN})
+    assert preview.headers.get("access-control-allow-origin") == PREVIEW_ORIGIN


### PR DESCRIPTION
## Summary
- Adds a fail-closed production route gate so `APP_ENV=production` exposes only `GET /api/health`.
- Disables `/docs`, `/redoc`, and `/openapi.json` in production.
- Rejects Vercel preview and unrelated CORS origins in production; keeps staging/local product routes and preview CORS intact.
- Documents a separate production Cloud Run service and runtime identity. Does not deploy production in this PR.

## Test plan
- [x] `.\.venv\Scripts\python.exe -m pytest -q` — 59 passed (46 baseline + production-safety tests)
- [x] Production health returns 200 with CORS for `https://sportbeacon-ai.vercel.app`
- [x] Production rejects preview and unrelated origins
- [x] Production insights, drills, matchmaking, experimental, and docs routes return 404
- [x] Missing production configuration fails closed
- [x] Non-production API contracts remain intact
- [x] Frontend type-check, lint, test (3), and build passed
- [ ] GitHub Actions and Vercel checks on this head
- [ ] Do not merge until every new production-safety test and existing baseline pass
- [ ] Do not start Phase 2B in this PR

Made with [Cursor](https://cursor.com)