### PR TITLE
chore: configure Firebase MCP for Cursor

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "firebase": {
+      "command": "npx",
+      "args": ["-y", "firebase-tools@latest", "mcp"]
+    }
+  }
+}

--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -1,0 +1,7 @@
+{
+  "plugins": {
+    "firebase": {
+      "enabled": true
+    }
+  }
+}

--- a/.cursor/settings.json
+++ b/.cursor/settings.json
@@ -1,7 +1,0 @@
-{
-  "plugins": {
-    "firebase": {
-      "enabled": true
-    }
-  }
-}


### PR DESCRIPTION
## Summary
- Replaces the first workspace-setting approach (`.cursor/settings.json` enabling a marketplace plugin flag). That file is not Firebase's documented project-level MCP configuration, so it is not being merged on its own.
- The repository now uses Firebase's documented project-level Cursor MCP configuration in `.cursor/mcp.json`.
- `firebase-tools@latest` is invoked through `npx` (`npx -y firebase-tools@latest mcp`).
- No credentials or project secrets are committed.
- No Firebase services were initialized. This PR does not add `firebase.json`, `.firebaserc`, Firestore, Authentication, Hosting, App Hosting, SQL Connect, or Data Connect resources.
- Phase 2B product development has not started.
- Marketplace plugin or agent-skills installation remains an editor-level setup step when needed.

## Test plan
- [x] `.cursor/mcp.json` is valid JSON and matches the documented `npx` Firebase MCP block
- [x] Node.js `v22.14.0` satisfies the Firebase CLI `>= 20` requirement; `npx -y firebase-tools@latest --version` reports `15.27.0`
- [x] Firebase MCP reports Connected/Ready in Cursor and its tools are available without committing tokens or secrets
- [x] Authoritative Google Cloud project remains `sportbeacon-ai`
- [x] GitHub Actions frontend, python, and legacy-node-backend succeeded on `0a8a4d3`; Vercel succeeded (manual merge gate, not an enforced protection context)
- [x] `main` branch protection is enabled: PRs required, 0 approvals, required checks `frontend (18.x)` / `python` / `legacy-node-backend (install only) (18.x)`, up to date with `main`, conversation resolution, linear history, no force pushes, no branch deletion, branch not locked, CODEOWNERS not required, admins not enforced
- [x] Diff contains only `.cursor/mcp.json`; no Cloud Run, IAM, or Vercel Production changes
- [x] Do not start Phase 2B in this PR