### PR TITLE
feat: add MVP core sports loop foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Athlete-first tools for grassroots sports: player insights, drill planning, and prototype matchmaking.
 
-This repository is a **bootable local web application** (Vite + FastAPI) plus a tested Python AI library. Phase 2B adds Firebase email/password authentication and a private athlete workspace. It is not a finished product. Payments, public profiles, Places, Runs, Groups, Messaging, and production matchmaking remain out of scope.
+This repository is a **bootable local web application** (Vite + FastAPI) plus a tested Python AI library. Phase 3A adds a first playable sports loop: Places, Runs, join, check-in, and private participation history on top of Firebase email/password authentication. It is not a finished product. Payments, public profiles, Groups, Messaging, RecTrac, and production matchmaking remain out of scope.
 
 ## Architecture
 
@@ -10,7 +10,7 @@ This repository is a **bootable local web application** (Vite + FastAPI) plus a 
 | --- | --- | --- |
 | Frontend | `frontend/` | React 18 + TypeScript + Vite athlete workspace |
 | Backend | `backend/api.py` | FastAPI health check and authenticated `/api/me` routes |
-| Persistence | Firestore via FastAPI | Private athlete profiles and basketball stats, separated by `APP_ENV` |
+| Persistence | Firestore via FastAPI | Private athlete profiles, stats, Places, Runs, and participation, separated by `APP_ENV` |
 | AI library | `ai/` | Player insights, drill recommender, matchmaking engine |
 | Tests | `tests/` | pytest contract, engine, auth, and emulator tests |
 
@@ -18,7 +18,7 @@ The Node package in `backend/` is **legacy**. It still installs with `npm ci`, b
 
 Legacy React files under `frontend/components`, `frontend/pages`, `frontend/services`, and `frontend/hooks` are not part of the bootable app. The Vite entrypoint is `frontend/src/main.tsx`. Do not import the legacy `frontend/services/authService.ts` token design.
 
-## Project scope (Phase 2B)
+## Project scope (Phase 3A)
 
 Included:
 
@@ -26,18 +26,23 @@ Included:
 - Private athlete profile onboarding and editing
 - Manual basketball stat persistence
 - Authenticated insight generation and drill recommendations from persisted data
+- Authenticated basketball Run discovery with Place details
+- Authenticated join and check-in, persisted as one participation record per athlete and run
+- Private participation history
+- Labeled development/staging test Place and Runs (not live municipal data)
 - Live FastAPI health check with loading, connected, and error/retry states
 - Disabled roadmap labels for later modules
 - Frontend lint, type-check, unit tests, and production build
-- Python pytest suite for the AI engines, API contracts, and authenticated routes
+- Python pytest suite for the AI engines, API contracts, authenticated routes, and sports-loop behavior
 
 Not included:
 
 - Google, Apple, phone, or anonymous authentication in the product UI
-- Runs, Places, Groups, Messaging, Beacon Alerts, heat maps, or a social feed
+- Athlete-to-athlete connections, group chat, messaging, or Beacon Alerts
 - Public athlete profiles or public Firestore access
 - Payments, RecTrac, TeamSideline, Cloud Functions, Storage, or AI chat
-- Fake games, courts, people, or live municipal data
+- Maps, geofencing, continuous location, or fake live occupancy
+- Live municipal schedules presented as production data
 
 ## Python setup
 
@@ -128,7 +133,8 @@ Backend (optional):
 | `CORS_ALLOW_ORIGIN_REGEX` | Optional override. Default allows SportBeacon Vercel git preview hosts only. Production sets `^$` so preview hosts are not echoed. |
 | `ENABLE_EXPERIMENTAL_ROUTES` | Defaults to `false`. Coach, highlight, and extended-schedule routes return 404 until explicitly enabled. |
 | `ENABLE_PRODUCT_ROUTES` | Defaults on only for `development` and `test`. Cannot reopen legacy product APIs in staging, production, or an invalid environment. |
-| `ENABLE_AUTHENTICATED_PROFILE_ROUTES` | Defaults to `false`. Staging sets `true`. Production stays `false` in this phase. Ignored when `APP_ENV` is missing or unrecognized. |
+| `ENABLE_AUTHENTICATED_PROFILE_ROUTES` | Defaults to `false`. Staging sets `true`. Production stays `false` in this phase. Gates `/api/me` and the Phase 3 Play routes. Ignored when `APP_ENV` is missing or unrecognized. |
+| `ENABLE_SPORTS_LOOP_FIXTURES` | When true, FastAPI upserts labeled test Place/Run documents. Defaults on for `development` and `staging`. Always off in `production`. Test defaults off unless set. |
 | `ENABLE_API_DOCS` | Defaults on for `development`, `test`, and `staging`. Disabled for `production` and for invalid `APP_ENV`. |
 | `APP_ENV` | Required. Exactly `development`, `test`, `staging`, or `production`. Missing, blank, `prod`, `preview`, and misspellings fail closed. |
 
@@ -144,8 +150,9 @@ npx -y firebase-tools@latest emulators:exec --only auth,firestore --project spor
 
 ## Known prototype limitations
 
-- The athlete workspace authenticates with email/password and persists a private profile and basketball stats through FastAPI.
-- Matchmaking, Places, Runs, Groups, and Messaging are roadmap labels only.
+- The athlete workspace authenticates with email/password and persists a private profile, basketball stats, and Run participation through FastAPI.
+- Play Today uses labeled test Place/Run fixtures in development and staging. Those are not live municipal listings.
+- Groups, Messaging, athlete connections, and Matchmaking remain roadmap work. See `docs/phase-3-core-sports-loop.md` and `docs/phase-3b-athlete-connection.md`.
 - Coach, highlight, media, and extended-schedule paths remain incomplete and are not started with the shell.
 - Historical `logs/` files were removed from Git tracking. Local copies may still exist. Do not commit Firebase config values or service-account keys.
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -20,6 +20,8 @@ ENABLE_API_DOCS=true
 # Required. Recognized values: development, test, staging, production.
 # Missing, blank, or unrecognized values fail closed (health only).
 APP_ENV=development
+# Labeled test Place/Run fixtures. Defaults on for development and staging; always off in production.
+ENABLE_SPORTS_LOOP_FIXTURES=true
 
 # Legacy Express / WebSocket configuration (not used by the FastAPI shell)
 CLIENT_ORIGIN=http://localhost:3000

--- a/backend/api.py
+++ b/backend/api.py
@@ -4,6 +4,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 from typing import Any, Dict, List, Optional
+import re
 from .models import (
     API_VERSION,
     SERVICE_NAME,
@@ -27,6 +28,7 @@ from .matchmaking_service import MatchmakingService
 from .drill_service import DrillService
 from .runtime_env import env_flag, parse_app_env
 from .me_routes import me_router
+from .sports_loop_routes import sports_router
 import os
 from datetime import datetime
 
@@ -119,7 +121,14 @@ AUTHENTICATED_PROFILE_ROUTES = {
     ("GET", "/api/me/stats"),
     ("POST", "/api/me/insights"),
     ("POST", "/api/me/drills/recommend"),
+    ("GET", "/api/me/participation"),
 }
+
+_RUN_ID = r"[A-Za-z0-9_-]{8,80}"
+_SPORTS_LOOP_GET_RUNS = re.compile(r"^/api/runs$")
+_SPORTS_LOOP_GET_RUN = re.compile(rf"^/api/runs/{_RUN_ID}$")
+_SPORTS_LOOP_JOIN = re.compile(rf"^/api/runs/{_RUN_ID}/join$")
+_SPORTS_LOOP_CHECK_IN = re.compile(rf"^/api/runs/{_RUN_ID}/check-in$")
 
 
 def is_authenticated_profile_request(method: str, path: str) -> bool:
@@ -128,6 +137,27 @@ def is_authenticated_profile_request(method: str, path: str) -> bool:
     if method == "OPTIONS":
         return any(candidate == normalized for _, candidate in AUTHENTICATED_PROFILE_ROUTES)
     return (method, normalized) in AUTHENTICATED_PROFILE_ROUTES
+
+
+def is_authenticated_sports_loop_request(method: str, path: str) -> bool:
+    """Allowlisted Place/Run participation routes. Invalid run ids fail closed to 404."""
+    normalized = path.rstrip("/") or "/"
+    method = method.upper()
+    if method in {"GET", "OPTIONS"} and (
+        _SPORTS_LOOP_GET_RUNS.fullmatch(normalized) or _SPORTS_LOOP_GET_RUN.fullmatch(normalized)
+    ):
+        return True
+    if method in {"POST", "OPTIONS"} and (
+        _SPORTS_LOOP_JOIN.fullmatch(normalized) or _SPORTS_LOOP_CHECK_IN.fullmatch(normalized)
+    ):
+        return True
+    return False
+
+
+def is_authenticated_athlete_request(method: str, path: str) -> bool:
+    return is_authenticated_profile_request(method, path) or is_authenticated_sports_loop_request(
+        method, path
+    )
 
 
 class RouteGateMiddleware(BaseHTTPMiddleware):
@@ -143,7 +173,7 @@ class RouteGateMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
         if product_routes_enabled():
             return await call_next(request)
-        if authenticated_profile_routes_enabled() and is_authenticated_profile_request(method, path):
+        if authenticated_profile_routes_enabled() and is_authenticated_athlete_request(method, path):
             return await call_next(request)
         return JSONResponse({"detail": PRODUCT_ROUTE_DETAIL}, status_code=404)
 
@@ -382,6 +412,7 @@ def create_app() -> FastAPI:
     application.add_middleware(RouteGateMiddleware)
     application.include_router(router)
     application.include_router(me_router)
+    application.include_router(sports_router)
     application.state.insight_service = insight_service
     application.state.drill_service = drill_service
     return application

--- a/backend/sports_loop_fixtures.py
+++ b/backend/sports_loop_fixtures.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from .sports_loop_models import Place, Run
+from .sports_loop_repository import SportsLoopRepository
+
+PLACE_ID = "test-place-richmond-rec-gym"
+ACTIVE_RUN_ID = "test-run-basketball-active"
+UPCOMING_RUN_ID = "test-run-basketball-upcoming"
+COMPLETED_RUN_ID = "test-run-basketball-completed"
+CANCELLED_RUN_ID = "test-run-basketball-cancelled"
+FIXTURE_CREATED_BY = "sportbeacon-fixture"
+
+
+def build_test_place(now: datetime) -> Place:
+    return Place(
+        id=PLACE_ID,
+        name="TEST DATA — Richmond Rec Gym",
+        city="Richmond",
+        region="VA",
+        country="US",
+        sportCapabilities=["basketball"],
+        latitude=37.5407,
+        longitude=-77.4360,
+        entranceNotes="Main gym entrance on the recreation center side. Test venue only.",
+        isTestData=True,
+        createdAt=now,
+        updatedAt=now,
+    )
+
+
+def build_test_runs(now: datetime, place_id: str = PLACE_ID) -> list[Run]:
+    stamp = now if now.tzinfo else now.replace(tzinfo=timezone.utc)
+    return [
+        Run(
+            id=ACTIVE_RUN_ID,
+            sport="basketball",
+            placeId=place_id,
+            title="TEST DATA — Lunch pickup run",
+            startsAt=stamp - timedelta(minutes=45),
+            endsAt=stamp + timedelta(minutes=75),
+            status="scheduled",
+            createdBy=FIXTURE_CREATED_BY,
+            visibility="authenticated",
+            isTestData=True,
+            createdAt=stamp,
+            updatedAt=stamp,
+        ),
+        Run(
+            id=UPCOMING_RUN_ID,
+            sport="basketball",
+            placeId=place_id,
+            title="TEST DATA — Evening open gym",
+            startsAt=stamp + timedelta(hours=3),
+            endsAt=stamp + timedelta(hours=5),
+            status="scheduled",
+            createdBy=FIXTURE_CREATED_BY,
+            visibility="authenticated",
+            isTestData=True,
+            createdAt=stamp,
+            updatedAt=stamp,
+        ),
+        Run(
+            id=COMPLETED_RUN_ID,
+            sport="basketball",
+            placeId=place_id,
+            title="TEST DATA — Yesterday's completed run",
+            startsAt=stamp - timedelta(hours=26),
+            endsAt=stamp - timedelta(hours=24),
+            status="scheduled",
+            createdBy=FIXTURE_CREATED_BY,
+            visibility="authenticated",
+            isTestData=True,
+            createdAt=stamp,
+            updatedAt=stamp,
+        ),
+        Run(
+            id=CANCELLED_RUN_ID,
+            sport="basketball",
+            placeId=place_id,
+            title="TEST DATA — Cancelled run",
+            startsAt=stamp + timedelta(hours=1),
+            endsAt=stamp + timedelta(hours=3),
+            status="cancelled",
+            createdBy=FIXTURE_CREATED_BY,
+            visibility="authenticated",
+            isTestData=True,
+            createdAt=stamp,
+            updatedAt=stamp,
+        ),
+    ]
+
+
+def ensure_sports_loop_fixtures(repo: SportsLoopRepository, now: datetime) -> None:
+    """Idempotently upsert labeled test Place/Runs. Never call in production."""
+    place = build_test_place(now)
+    existing_place = repo.get_place(place.id)
+    if existing_place is not None:
+        place = existing_place.model_copy(
+            update={
+                "name": place.name,
+                "city": place.city,
+                "region": place.region,
+                "country": place.country,
+                "sportCapabilities": place.sportCapabilities,
+                "latitude": place.latitude,
+                "longitude": place.longitude,
+                "entranceNotes": place.entranceNotes,
+                "isTestData": True,
+                "updatedAt": now,
+            }
+        )
+    repo.upsert_place(place)
+    for run in build_test_runs(now, place.id):
+        existing = repo.get_run(run.id)
+        if existing is not None:
+            run = existing.model_copy(
+                update={
+                    "sport": run.sport,
+                    "placeId": run.placeId,
+                    "title": run.title,
+                    "startsAt": run.startsAt,
+                    "endsAt": run.endsAt,
+                    "status": run.status,
+                    "visibility": run.visibility,
+                    "isTestData": True,
+                    "updatedAt": now,
+                }
+            )
+        repo.upsert_run(run)

--- a/backend/sports_loop_models.py
+++ b/backend/sports_loop_models.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Literal, Optional, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from .athlete_models import CANONICAL_SPORTS, FORBIDDEN_IDENTITY_FIELDS
+
+RunStoredStatus = Literal["scheduled", "cancelled"]
+RunComputedStatus = Literal["upcoming", "active", "completed", "cancelled"]
+ParticipationStatus = Literal["going", "checked_in", "completed", "withdrawn"]
+RunVisibility = Literal["authenticated"]
+
+
+class ExternalProviderRef(BaseModel):
+    """Optional adapter pointer. Never required on canonical Place or Run documents."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    provider: str = Field(min_length=1, max_length=40)
+    externalId: str = Field(min_length=1, max_length=120)
+    sourceMetadata: Dict[str, str] = Field(default_factory=dict)
+
+
+class Place(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(min_length=8, max_length=80)
+    name: str = Field(min_length=1, max_length=120)
+    city: str = Field(min_length=1, max_length=80)
+    region: str = Field(min_length=1, max_length=80)
+    country: str = Field(min_length=2, max_length=80)
+    sportCapabilities: List[str] = Field(min_length=1, max_length=8)
+    latitude: Optional[float] = Field(default=None, ge=-90, le=90)
+    longitude: Optional[float] = Field(default=None, ge=-180, le=180)
+    entranceNotes: Optional[str] = Field(default=None, max_length=280)
+    isTestData: bool = False
+    externalRefs: List[ExternalProviderRef] = Field(default_factory=list, max_length=8)
+    createdAt: datetime
+    updatedAt: datetime
+
+    @field_validator("sportCapabilities")
+    @classmethod
+    def _canonical_sports(cls, value: List[str]) -> List[str]:
+        sports: List[str] = []
+        for item in value:
+            sport = item.strip().lower()
+            if sport not in CANONICAL_SPORTS:
+                raise ValueError("Unsupported sport")
+            if sport not in sports:
+                sports.append(sport)
+        if not sports:
+            raise ValueError("sportCapabilities is required")
+        return sports
+
+    @field_validator("id")
+    @classmethod
+    def _id_shape(cls, value: str) -> str:
+        return _require_resource_id(value)
+
+
+class Run(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(min_length=8, max_length=80)
+    sport: str
+    placeId: str = Field(min_length=8, max_length=80)
+    title: str = Field(min_length=1, max_length=160)
+    startsAt: datetime
+    endsAt: datetime
+    status: RunStoredStatus = "scheduled"
+    createdBy: str = Field(min_length=1, max_length=80)
+    capacity: Optional[int] = Field(default=None, ge=2, le=200)
+    visibility: RunVisibility = "authenticated"
+    isTestData: bool = False
+    externalRefs: List[ExternalProviderRef] = Field(default_factory=list, max_length=8)
+    createdAt: datetime
+    updatedAt: datetime
+
+    @field_validator("id", "placeId")
+    @classmethod
+    def _id_shape(cls, value: str) -> str:
+        return _require_resource_id(value)
+
+    @field_validator("sport")
+    @classmethod
+    def _canonical_sport(cls, value: str) -> str:
+        sport = value.strip().lower()
+        if sport not in CANONICAL_SPORTS:
+            raise ValueError("Unsupported sport")
+        return sport
+
+    @field_validator("startsAt", "endsAt", "createdAt", "updatedAt")
+    @classmethod
+    def _aware(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("Timestamps must be timezone-aware")
+        return value
+
+
+class Participation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    uid: str = Field(min_length=1, max_length=128)
+    runId: str = Field(min_length=8, max_length=80)
+    status: ParticipationStatus
+    joinedAt: datetime
+    checkedInAt: Optional[datetime] = None
+    runTitle: str = Field(min_length=1, max_length=160)
+    placeId: str = Field(min_length=8, max_length=80)
+    placeName: str = Field(min_length=1, max_length=120)
+    sport: str
+    startsAt: datetime
+    isTestData: bool = False
+
+    @field_validator("runId", "placeId")
+    @classmethod
+    def _id_shape(cls, value: str) -> str:
+        return _require_resource_id(value)
+
+    @field_validator("sport")
+    @classmethod
+    def _canonical_sport(cls, value: str) -> str:
+        sport = value.strip().lower()
+        if sport not in CANONICAL_SPORTS:
+            raise ValueError("Unsupported sport")
+        return sport
+
+
+class PlaceSummary(BaseModel):
+    id: str
+    name: str
+    city: str
+    region: str
+    country: str
+    entranceNotes: Optional[str] = None
+    isTestData: bool = False
+
+
+class MyParticipationView(BaseModel):
+    status: ParticipationStatus
+    joinedAt: datetime
+    checkedInAt: Optional[datetime] = None
+
+
+class RunView(BaseModel):
+    id: str
+    sport: str
+    placeId: str
+    title: str
+    startsAt: datetime
+    endsAt: datetime
+    status: RunComputedStatus
+    visibility: RunVisibility
+    isTestData: bool = False
+    capacity: Optional[int] = None
+    checkInOpen: bool = False
+    place: PlaceSummary
+    myParticipation: Optional[MyParticipationView] = None
+
+
+class RunListResponse(BaseModel):
+    items: List[RunView]
+    sport: str = "basketball"
+    isTestData: bool = False
+
+
+class ParticipationHistoryItem(BaseModel):
+    runId: str
+    runTitle: str
+    placeId: str
+    placeName: str
+    sport: str
+    startsAt: datetime
+    status: ParticipationStatus
+    joinedAt: datetime
+    checkedInAt: Optional[datetime] = None
+    isTestData: bool = False
+
+
+class ParticipationHistoryResponse(BaseModel):
+    items: List[ParticipationHistoryItem]
+
+
+class ProviderAdapter(Protocol):
+    """Future boundary: providers never own SportBeacon Place/Run identity."""
+
+    def provider_name(self) -> str: ...
+
+
+def reject_sports_loop_identity_fields(payload: Dict[str, Any]) -> None:
+    present = sorted(FORBIDDEN_IDENTITY_FIELDS.intersection(payload.keys()))
+    if present:
+        raise ValueError("Identity fields are not allowed in the request body")
+
+
+def _require_resource_id(value: str) -> str:
+    cleaned = value.strip()
+    if len(cleaned) < 8 or len(cleaned) > 80:
+        raise ValueError("Invalid resource id")
+    allowed = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-")
+    if any(char not in allowed for char in cleaned):
+        raise ValueError("Invalid resource id")
+    return cleaned

--- a/backend/sports_loop_repository.py
+++ b/backend/sports_loop_repository.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from datetime import datetime
+from threading import Lock
+from typing import Callable, Dict, List, Optional, Protocol, Tuple
+
+from .runtime_env import require_app_env
+from .sports_loop_models import Participation, Place, Run
+
+
+class SportsLoopRepository(Protocol):
+    def upsert_place(self, place: Place) -> Place: ...
+
+    def get_place(self, place_id: str) -> Optional[Place]: ...
+
+    def upsert_run(self, run: Run) -> Run: ...
+
+    def get_run(self, run_id: str) -> Optional[Run]: ...
+
+    def list_runs_by_sport(self, sport: str, *, limit: int = 50) -> List[Run]: ...
+
+    def get_participation(self, run_id: str, uid: str) -> Optional[Participation]: ...
+
+    def commit_join(self, record: Participation) -> Participation: ...
+
+    def commit_check_in(
+        self,
+        uid: str,
+        run_id: str,
+        now: datetime,
+        create: Callable[[], Participation],
+    ) -> Participation: ...
+
+    def list_participations(self, uid: str, *, limit: int = 50) -> List[Participation]: ...
+
+
+class InMemorySportsLoopRepository:
+    def __init__(self) -> None:
+        self.places: Dict[str, Place] = {}
+        self.runs: Dict[str, Run] = {}
+        self._participants: Dict[Tuple[str, str], Participation] = {}
+        self._lock = Lock()
+
+    def upsert_place(self, place: Place) -> Place:
+        self.places[place.id] = place
+        return place
+
+    def get_place(self, place_id: str) -> Optional[Place]:
+        return self.places.get(place_id)
+
+    def upsert_run(self, run: Run) -> Run:
+        self.runs[run.id] = run
+        return run
+
+    def get_run(self, run_id: str) -> Optional[Run]:
+        return self.runs.get(run_id)
+
+    def list_runs_by_sport(self, sport: str, *, limit: int = 50) -> List[Run]:
+        matched = [item for item in self.runs.values() if item.sport == sport]
+        matched.sort(key=lambda item: item.startsAt)
+        return matched[:limit]
+
+    def get_participation(self, run_id: str, uid: str) -> Optional[Participation]:
+        return self._participants.get((run_id, uid))
+
+    def commit_join(self, record: Participation) -> Participation:
+        with self._lock:
+            existing = self._participants.get((record.runId, record.uid))
+            if existing is not None:
+                return existing
+            self._participants[(record.runId, record.uid)] = record
+            return record
+
+    def commit_check_in(
+        self,
+        uid: str,
+        run_id: str,
+        now: datetime,
+        create: Callable[[], Participation],
+    ) -> Participation:
+        with self._lock:
+            existing = self._participants.get((run_id, uid))
+            if existing is not None and existing.checkedInAt is not None:
+                return existing
+            if existing is not None:
+                updated = existing.model_copy(
+                    update={"status": "checked_in", "checkedInAt": now}
+                )
+                self._participants[(run_id, uid)] = updated
+                return updated
+            created = create()
+            self._participants[(created.runId, created.uid)] = created
+            return created
+
+    def list_participations(self, uid: str, *, limit: int = 50) -> List[Participation]:
+        items = [item for item in self._participants.values() if item.uid == uid]
+        items.sort(key=lambda item: item.startsAt, reverse=True)
+        return items[:limit]
+
+
+class FirestoreSportsLoopRepository:
+    def __init__(self, client=None, app_env: Optional[str] = None) -> None:
+        if client is None:
+            from .firebase_admin_app import get_firestore_client
+
+            client = get_firestore_client()
+        self._client = client
+        self._app_env = app_env or require_app_env()
+
+    def _env_ref(self):
+        return self._client.collection("environments").document(self._app_env)
+
+    def _place_ref(self, place_id: str):
+        return self._env_ref().collection("places").document(place_id)
+
+    def _run_ref(self, run_id: str):
+        return self._env_ref().collection("runs").document(run_id)
+
+    def _participant_ref(self, run_id: str, uid: str):
+        return self._run_ref(run_id).collection("participants").document(uid)
+
+    def _athlete_participation_ref(self, uid: str, run_id: str):
+        return (
+            self._env_ref()
+            .collection("athletes")
+            .document(uid)
+            .collection("participations")
+            .document(run_id)
+        )
+
+    def upsert_place(self, place: Place) -> Place:
+        self._place_ref(place.id).set(place.model_dump())
+        return place
+
+    def get_place(self, place_id: str) -> Optional[Place]:
+        snapshot = self._place_ref(place_id).get()
+        if not snapshot.exists:
+            return None
+        return Place.model_validate(snapshot.to_dict())
+
+    def upsert_run(self, run: Run) -> Run:
+        self._run_ref(run.id).set(run.model_dump())
+        return run
+
+    def get_run(self, run_id: str) -> Optional[Run]:
+        snapshot = self._run_ref(run_id).get()
+        if not snapshot.exists:
+            return None
+        return Run.model_validate(snapshot.to_dict())
+
+    def list_runs_by_sport(self, sport: str, *, limit: int = 50) -> List[Run]:
+        query = self._env_ref().collection("runs").where("sport", "==", sport).limit(limit)
+        return [Run.model_validate(doc.to_dict()) for doc in query.stream()]
+
+    def get_participation(self, run_id: str, uid: str) -> Optional[Participation]:
+        snapshot = self._participant_ref(run_id, uid).get()
+        if not snapshot.exists:
+            return None
+        return Participation.model_validate(snapshot.to_dict())
+
+    def commit_join(self, record: Participation) -> Participation:
+        from google.cloud import firestore
+
+        participant_ref = self._participant_ref(record.runId, record.uid)
+        athlete_ref = self._athlete_participation_ref(record.uid, record.runId)
+        transaction = self._client.transaction()
+
+        @firestore.transactional
+        def _txn(txn):
+            snapshot = participant_ref.get(transaction=txn)
+            if snapshot.exists:
+                return Participation.model_validate(snapshot.to_dict())
+            payload = record.model_dump()
+            txn.set(participant_ref, payload)
+            txn.set(athlete_ref, payload)
+            return record
+
+        return _txn(transaction)
+
+    def commit_check_in(
+        self,
+        uid: str,
+        run_id: str,
+        now: datetime,
+        create: Callable[[], Participation],
+    ) -> Participation:
+        from google.cloud import firestore
+
+        participant_ref = self._participant_ref(run_id, uid)
+        athlete_ref = self._athlete_participation_ref(uid, run_id)
+        transaction = self._client.transaction()
+
+        @firestore.transactional
+        def _txn(txn):
+            snapshot = participant_ref.get(transaction=txn)
+            if snapshot.exists:
+                existing = Participation.model_validate(snapshot.to_dict())
+                if existing.checkedInAt is not None:
+                    return existing
+                updated = existing.model_copy(
+                    update={"status": "checked_in", "checkedInAt": now}
+                )
+                payload = updated.model_dump()
+                txn.set(participant_ref, payload)
+                txn.set(athlete_ref, payload)
+                return updated
+            created = create()
+            payload = created.model_dump()
+            txn.set(participant_ref, payload)
+            txn.set(athlete_ref, payload)
+            return created
+
+        return _txn(transaction)
+
+    def list_participations(self, uid: str, *, limit: int = 50) -> List[Participation]:
+        query = (
+            self._env_ref()
+            .collection("athletes")
+            .document(uid)
+            .collection("participations")
+            .order_by("startsAt", direction="DESCENDING")
+            .limit(limit)
+        )
+        return [Participation.model_validate(doc.to_dict()) for doc in query.stream()]

--- a/backend/sports_loop_routes.py
+++ b/backend/sports_loop_routes.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+from typing import Annotated, Any, Dict
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request
+
+from .athlete_models import reject_identity_fields
+from .athlete_repository import AthleteRepository
+from .me_routes import get_athlete_repository
+from .sports_loop_models import ParticipationHistoryResponse, RunListResponse, RunView
+from .sports_loop_repository import FirestoreSportsLoopRepository, SportsLoopRepository
+from .sports_loop_service import SportsLoopError, SportsLoopService
+from .token_auth import AuthenticatedUser, get_current_user
+
+sports_router = APIRouter(tags=["sports-loop"])
+RunId = Annotated[str, Path(min_length=8, max_length=80, pattern=r"^[A-Za-z0-9_-]{8,80}$")]
+
+
+def get_sports_loop_repository(request: Request) -> SportsLoopRepository:
+    repo = getattr(request.app.state, "sports_loop_repository", None)
+    if repo is None:
+        repo = FirestoreSportsLoopRepository()
+        request.app.state.sports_loop_repository = repo
+    return repo
+
+
+def get_sports_loop_service(
+    request: Request,
+    repo: SportsLoopRepository = Depends(get_sports_loop_repository),
+) -> SportsLoopService:
+    clock = getattr(request.app.state, "sports_loop_clock", None)
+    return SportsLoopService(repo, clock=clock)
+
+
+def _raise_loop_error(exc: SportsLoopError) -> None:
+    raise HTTPException(status_code=exc.status_code, detail=exc.detail) from None
+
+
+@sports_router.get("/api/runs", response_model=RunListResponse)
+async def list_playable_runs(
+    user: AuthenticatedUser = Depends(get_current_user),
+    service: SportsLoopService = Depends(get_sports_loop_service),
+    athlete_repo: AthleteRepository = Depends(get_athlete_repository),
+    sport: str = Query(default="basketball", max_length=40),
+) -> RunListResponse:
+    if sport.strip().lower() != "basketball":
+        raise HTTPException(status_code=422, detail="Only basketball discovery is available")
+    profile = athlete_repo.get_profile(user.uid)
+    home_area = profile.homeArea if profile is not None else None
+    try:
+        items = service.discover_runs(user.uid, sport="basketball", home_area=home_area)
+    except SportsLoopError as exc:
+        _raise_loop_error(exc)
+    return RunListResponse(
+        items=items,
+        sport="basketball",
+        isTestData=any(item.isTestData for item in items),
+    )
+
+
+@sports_router.get("/api/runs/{run_id}", response_model=RunView)
+async def read_run(
+    run_id: RunId,
+    user: AuthenticatedUser = Depends(get_current_user),
+    service: SportsLoopService = Depends(get_sports_loop_service),
+) -> RunView:
+    try:
+        return service.get_run(user.uid, run_id)
+    except SportsLoopError as exc:
+        _raise_loop_error(exc)
+
+
+@sports_router.post("/api/runs/{run_id}/join", response_model=RunView)
+async def join_run(
+    request: Request,
+    run_id: RunId,
+    user: AuthenticatedUser = Depends(get_current_user),
+    service: SportsLoopService = Depends(get_sports_loop_service),
+) -> RunView:
+    await _reject_identity_body(request)
+    try:
+        return service.join(user.uid, run_id)
+    except SportsLoopError as exc:
+        _raise_loop_error(exc)
+
+
+@sports_router.post("/api/runs/{run_id}/check-in", response_model=RunView)
+async def check_in_run(
+    request: Request,
+    run_id: RunId,
+    user: AuthenticatedUser = Depends(get_current_user),
+    service: SportsLoopService = Depends(get_sports_loop_service),
+) -> RunView:
+    await _reject_identity_body(request)
+    try:
+        return service.check_in(user.uid, run_id)
+    except SportsLoopError as exc:
+        _raise_loop_error(exc)
+
+
+@sports_router.get("/api/me/participation", response_model=ParticipationHistoryResponse)
+async def list_my_participation(
+    user: AuthenticatedUser = Depends(get_current_user),
+    service: SportsLoopService = Depends(get_sports_loop_service),
+) -> ParticipationHistoryResponse:
+    return ParticipationHistoryResponse(items=service.list_history(user.uid))
+
+
+async def _reject_identity_body(request: Request) -> Dict[str, Any]:
+    raw = await request.body()
+    if not raw.strip():
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail="Request body must be JSON") from None
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise HTTPException(status_code=400, detail="Request body must be a JSON object")
+    try:
+        reject_identity_fields(data)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+    if data:
+        raise HTTPException(status_code=400, detail="This request does not accept a body")
+    return data

--- a/backend/sports_loop_service.py
+++ b/backend/sports_loop_service.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Callable, List, Optional
+
+from .athlete_models import HomeArea
+from .runtime_env import env_flag, parse_app_env
+from .sports_loop_fixtures import ensure_sports_loop_fixtures
+from .sports_loop_models import (
+    MyParticipationView,
+    Participation,
+    ParticipationHistoryItem,
+    Place,
+    PlaceSummary,
+    Run,
+    RunComputedStatus,
+    RunView,
+)
+from .sports_loop_repository import SportsLoopRepository
+
+logger = logging.getLogger("sportbeacon.sports_loop")
+
+DISCOVERY_SPORT = "basketball"
+DISCOVERY_AHEAD = timedelta(days=7)
+CHECK_IN_LEAD = timedelta(minutes=30)
+Clock = Callable[[], datetime]
+
+
+class SportsLoopError(Exception):
+    def __init__(self, status_code: int, detail: str) -> None:
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def sports_loop_fixtures_enabled() -> bool:
+    env = parse_app_env()
+    if env is None or env == "production":
+        return False
+    flag = env_flag("ENABLE_SPORTS_LOOP_FIXTURES")
+    if flag is not None:
+        return flag
+    return env in {"development", "staging"}
+
+
+def compute_run_status(run: Run, now: datetime) -> RunComputedStatus:
+    if run.status == "cancelled":
+        return "cancelled"
+    if now > run.endsAt:
+        return "completed"
+    if run.startsAt <= now <= run.endsAt:
+        return "active"
+    return "upcoming"
+
+
+def check_in_is_open(run: Run, now: datetime) -> bool:
+    status = compute_run_status(run, now)
+    if status in {"cancelled", "completed"}:
+        return False
+    return (run.startsAt - CHECK_IN_LEAD) <= now <= run.endsAt
+
+
+class SportsLoopService:
+    def __init__(self, repo: SportsLoopRepository, clock: Optional[Clock] = None) -> None:
+        self._repo = repo
+        self._clock = clock or utc_now
+
+    def _now(self) -> datetime:
+        stamp = self._clock()
+        if stamp.tzinfo is None or stamp.utcoffset() is None:
+            return stamp.replace(tzinfo=timezone.utc)
+        return stamp.astimezone(timezone.utc)
+
+    def ensure_fixtures_if_enabled(self) -> None:
+        if not sports_loop_fixtures_enabled():
+            return
+        ensure_sports_loop_fixtures(self._repo, self._now())
+
+    def discover_runs(
+        self,
+        uid: str,
+        *,
+        sport: str = DISCOVERY_SPORT,
+        home_area: Optional[HomeArea] = None,
+    ) -> List[RunView]:
+        self.ensure_fixtures_if_enabled()
+        now = self._now()
+        horizon = now + DISCOVERY_AHEAD
+        views: List[RunView] = []
+        for run in self._repo.list_runs_by_sport(sport):
+            status = compute_run_status(run, now)
+            if status in {"cancelled", "completed"}:
+                continue
+            if run.startsAt > horizon:
+                continue
+            if run.visibility != "authenticated":
+                continue
+            place = self._repo.get_place(run.placeId)
+            if place is None:
+                logger.warning("discover_missing_place", extra={"run_id": run.id})
+                continue
+            participation = self._repo.get_participation(run.id, uid)
+            views.append(_to_run_view(run, place, participation, now))
+        views.sort(key=lambda item: (_home_rank(item, home_area), item.startsAt, item.id))
+        return views
+
+    def get_run(self, uid: str, run_id: str) -> RunView:
+        self.ensure_fixtures_if_enabled()
+        run, place = self._require_run_and_place(run_id)
+        participation = self._repo.get_participation(run.id, uid)
+        return _to_run_view(run, place, participation, self._now())
+
+    def join(self, uid: str, run_id: str) -> RunView:
+        self.ensure_fixtures_if_enabled()
+        run, place = self._require_run_and_place(run_id)
+        now = self._now()
+        status = compute_run_status(run, now)
+        if status in {"cancelled", "completed"}:
+            logger.warning("join_rejected", extra={"run_id": run_id, "reason": status})
+            raise SportsLoopError(409, "This run is not open to join")
+        record = _participation_snapshot(uid, run, place, status="going", joined_at=now, checked_in_at=None)
+        stored = self._repo.commit_join(record)
+        return _to_run_view(run, place, stored, now)
+
+    def check_in(self, uid: str, run_id: str) -> RunView:
+        self.ensure_fixtures_if_enabled()
+        run, place = self._require_run_and_place(run_id)
+        now = self._now()
+        if not check_in_is_open(run, now):
+            status = compute_run_status(run, now)
+            logger.warning("check_in_rejected", extra={"run_id": run_id, "reason": status})
+            raise SportsLoopError(409, "Check-in is not available for this run yet")
+
+        def _create() -> Participation:
+            return _participation_snapshot(
+                uid, run, place, status="checked_in", joined_at=now, checked_in_at=now
+            )
+
+        stored = self._repo.commit_check_in(uid, run.id, now, _create)
+        return _to_run_view(run, place, stored, now)
+
+    def list_history(self, uid: str) -> List[ParticipationHistoryItem]:
+        self.ensure_fixtures_if_enabled()
+        items = []
+        for record in self._repo.list_participations(uid):
+            items.append(
+                ParticipationHistoryItem(
+                    runId=record.runId,
+                    runTitle=record.runTitle,
+                    placeId=record.placeId,
+                    placeName=record.placeName,
+                    sport=record.sport,
+                    startsAt=record.startsAt,
+                    status=record.status,
+                    joinedAt=record.joinedAt,
+                    checkedInAt=record.checkedInAt,
+                    isTestData=record.isTestData,
+                )
+            )
+        return items
+
+    def _require_run_and_place(self, run_id: str) -> tuple[Run, Place]:
+        run = self._repo.get_run(run_id)
+        if run is None:
+            logger.warning("run_not_found", extra={"run_id": run_id})
+            raise SportsLoopError(404, "Run not found")
+        place = self._repo.get_place(run.placeId)
+        if place is None:
+            logger.warning("run_place_missing", extra={"run_id": run_id})
+            raise SportsLoopError(404, "Run not found")
+        return run, place
+
+
+def _participation_snapshot(
+    uid: str,
+    run: Run,
+    place: Place,
+    *,
+    status: str,
+    joined_at: datetime,
+    checked_in_at: Optional[datetime],
+) -> Participation:
+    return Participation(
+        uid=uid,
+        runId=run.id,
+        status=status,
+        joinedAt=joined_at,
+        checkedInAt=checked_in_at,
+        runTitle=run.title,
+        placeId=place.id,
+        placeName=place.name,
+        sport=run.sport,
+        startsAt=run.startsAt,
+        isTestData=run.isTestData or place.isTestData,
+    )
+
+
+def _to_run_view(
+    run: Run,
+    place: Place,
+    participation: Optional[Participation],
+    now: datetime,
+) -> RunView:
+    mine = None
+    if participation is not None:
+        mine = MyParticipationView(
+            status=participation.status,
+            joinedAt=participation.joinedAt,
+            checkedInAt=participation.checkedInAt,
+        )
+    return RunView(
+        id=run.id,
+        sport=run.sport,
+        placeId=run.placeId,
+        title=run.title,
+        startsAt=run.startsAt,
+        endsAt=run.endsAt,
+        status=compute_run_status(run, now),
+        visibility=run.visibility,
+        isTestData=run.isTestData or place.isTestData,
+        capacity=run.capacity,
+        checkInOpen=check_in_is_open(run, now),
+        place=PlaceSummary(
+            id=place.id,
+            name=place.name,
+            city=place.city,
+            region=place.region,
+            country=place.country,
+            entranceNotes=place.entranceNotes,
+            isTestData=place.isTestData,
+        ),
+        myParticipation=mine,
+    )
+
+
+def _home_rank(item: RunView, home_area: Optional[HomeArea]) -> tuple[int, int]:
+    if home_area is None:
+        return (1, 1)
+    city_match = item.place.city.strip().lower() == home_area.city.strip().lower()
+    region_match = item.place.region.strip().lower() == home_area.region.strip().lower()
+    return (0 if city_match else 1, 0 if region_match else 1)

--- a/docs/cloud-run-deployment.md
+++ b/docs/cloud-run-deployment.md
@@ -18,7 +18,7 @@ Recreate the SportBeacon FastAPI **staging** and **production** services from th
 | Runtime identity | `sportbeacon-api-runtime@sportbeacon-ai.iam.gserviceaccount.com` |
 | Staging URL | `https://sportbeacon-api-staging-104921686559.us-east1.run.app` |
 
-Staging keeps unauthenticated product APIs closed even if `ENABLE_PRODUCT_ROUTES=true`. Experimental coach, highlight, and extended-schedule routes stay disabled. Phase 2B staging enables authenticated `/api/me` routes only when `APP_ENV=staging` and `ENABLE_AUTHENTICATED_PROFILE_ROUTES=true`. Missing or unrecognized `APP_ENV` values fail closed to health-only.
+Staging keeps unauthenticated product APIs closed even if `ENABLE_PRODUCT_ROUTES=true`. Experimental coach, highlight, and extended-schedule routes stay disabled. Phase 3A staging enables authenticated `/api/me` and Play routes (`/api/runs`, join, check-in, participation history) when `APP_ENV=staging` and `ENABLE_AUTHENTICATED_PROFILE_ROUTES=true`. Labeled test Place/Run fixtures default on in staging. Missing or unrecognized `APP_ENV` values fail closed to health-only.
 
 Non-secret staging environment (also in `deploy/cloud-run-staging.env.example`):
 

--- a/docs/phase-3-core-sports-loop.md
+++ b/docs/phase-3-core-sports-loop.md
@@ -1,0 +1,197 @@
+# Phase 3A — MVP Core Sports Loop
+
+Status: implemented on `feat/mvp-core-sports-loop`. This document is the architecture record for the first playable vertical slice.
+
+## Existing baseline
+
+Phase 2B (squash SHA `99c67f8614d08d638f4c66005bd5bffcd7df5226`) provides:
+
+- Firebase email/password authentication in the Vite app
+- private persisted athlete profiles and basketball statistics
+- authenticated insights and drill recommendations from persisted data
+- server-mediated Firestore access under `environments/{appEnv}/...`
+- direct client Firestore denial (`allow read, write: if false`)
+- fail-closed `APP_ENV` and route gating
+- staging Cloud Run with `ENABLE_AUTHENTICATED_PROFILE_ROUTES=true`
+- production Cloud Run remaining health-only
+- Vercel frontend deployment and required GitHub CI
+
+Phase 3A does not redesign or weaken those controls.
+
+## User outcome
+
+An authenticated athlete can answer **Can I play basketball today?** by:
+
+1. viewing basketball runs;
+2. seeing the Place for each run;
+3. distinguishing upcoming vs active;
+4. opening a run;
+5. joining (`I'm going`);
+6. checking in when the run is in the check-in window;
+7. seeing participation recorded;
+8. refreshing or signing back in and retaining that history.
+
+No manual Firestore editing is required. Development and staging use explicitly labeled test fixtures. Those fixtures are not live municipal data.
+
+## Existing relevant code
+
+| Path | Classification | Phase 3A use |
+| --- | --- | --- |
+| `backend/api.py`, `me_routes.py`, `token_auth.py`, `athlete_repository.py` | Canonical | Extend the same auth + server-mediated Firestore pattern |
+| `backend/runtime_env.py` | Canonical | Fail-closed env and flags |
+| `frontend/src/App.tsx`, `frontend/src/api/client.ts` | Canonical | Add Play without replacing Profile/Stats/Insights |
+| `firestore.rules` | Canonical | Keep deny-all client access |
+| `backend/services/venue_service.py`, `backend/routes/venues.js` | Legacy / prototype | Mapbox venue lookup. Not reused. |
+| `backend/workout_partner.py` | Prototype | In-memory sample venues and distance ranking. Not reused. |
+| `backend/routes/player-locations.js` | Unsafe / out of scope | Continuous location adjacent. Not reused. |
+| `backend/matchmaking_service.py`, `ai/matchmaking_engine.py` | Prototype engines | Unauthenticated product APIs remain gated. Not the sports loop. |
+| `frontend/components/*`, `frontend/services/eventService.ts`, `frontend/services/communityFeed.ts` | Legacy Vite-excluded UI | Not imported by `frontend/src/main.tsx`. Not reused. |
+| `backend/app.js` and Express routes | Legacy Node | Install-only. Not the active backend. |
+
+## Canonical model proposal
+
+```
+Athlete → Place → Run → Participation (with CheckIn timestamps)
+```
+
+Future (not implemented):
+
+```
+Shared verified participation → AthleteConnection → Community return
+```
+
+### Place
+
+A real sports/recreation location. Not a residence. Not a RecTrac row.
+
+Minimum fields: `id`, `name`, `city`, `region`, `country`, `sportCapabilities`, optional public venue `latitude`/`longitude`, optional `entranceNotes`, `isTestData`, `createdAt`, `updatedAt`.
+
+Optional future-compatible `externalRefs[]` (`provider`, `externalId`, optional `sourceMetadata`). Never required.
+
+### Run
+
+A playable sports session at a Place.
+
+Minimum fields: `id`, `sport`, `placeId`, `title`, `startsAt`, `endsAt`, stored `status` (`scheduled` or `cancelled`), `createdBy`, optional `capacity`, `visibility`, `isTestData`, `createdAt`, `updatedAt`.
+
+API `status` is computed from server UTC time:
+
+| Computed status | Rule |
+| --- | --- |
+| `cancelled` | stored status is `cancelled` |
+| `completed` | `now > endsAt` |
+| `active` | `startsAt <= now <= endsAt` |
+| `upcoming` | `now < startsAt` |
+
+`active` and `completed` are not persisted as separate organizer states in Phase 3A.
+
+### Participation
+
+One authoritative record per `athlete + run`.
+
+Fields: `uid` (server-assigned), `runId`, `status` (`going` \| `checked_in` \| `completed` \| `withdrawn`), `joinedAt`, optional `checkedInAt`, denormalized `runTitle`, `placeId`, `placeName`, `sport`, `startsAt`, `isTestData`.
+
+Join is idempotent. Duplicate concurrent joins cannot create a second logical record.
+
+### CheckIn
+
+**Decision: Check-in is a state and timestamp on Participation, not a separate document.**
+
+Phase 3A has no audit/compliance requirement for an independent check-in event stream. A second collection would duplicate the athlete+run key and add index/authorization cost without changing the user outcome.
+
+Check-in is authenticated, server-authoritative, bound to the verified token UID, bound to an existing Run, and idempotent. If no participation exists and the run is inside the check-in window, check-in atomically creates `checked_in` participation.
+
+Check-in window: `startsAt - 30 minutes <= now <= endsAt`, and the run is not cancelled or completed.
+
+## Privacy model
+
+| Resource | Phase 3A visibility |
+| --- | --- |
+| Place | Authenticated athletes may read venue-safe fields through the API. No residential addresses. |
+| Run | Discoverable to authenticated athletes according to server policy (`visibility=authenticated`). |
+| Participation | The athlete sees only their own participation. No participant roster. No fabricated attendance. Aggregate counts are omitted. |
+| Athlete profile / stats | Unchanged: private, server-mediated, UID from verified token. |
+
+The browser still cannot read or write Firestore. Places and Runs are **not** opened as public client-readable collections in this phase.
+
+No continuous GPS, background location, location trails, or precise athlete movement history.
+
+## API design
+
+All routes require a verified Firebase bearer token. Request bodies cannot set `uid` or impersonate another athlete.
+
+| Method | Path | Behavior |
+| --- | --- | --- |
+| `GET` | `/api/runs` | Active and upcoming basketball runs in the near-term window, with Place and the caller's participation. |
+| `GET` | `/api/runs/{runId}` | One run with Place and the caller's participation. |
+| `POST` | `/api/runs/{runId}/join` | Idempotent join. Rejects cancelled/completed runs. |
+| `POST` | `/api/runs/{runId}/check-in` | Idempotent check-in inside the window. May create participation. |
+| `GET` | `/api/me/participation` | Caller's participation history, newest first. |
+
+Not exposed: Place CRUD, Run CRUD, leave, rosters, geospatial search, organizer dashboards.
+
+Route gating reuses `ENABLE_AUTHENTICATED_PROFILE_ROUTES` so staging does not need a new Cloud Run flag. Invalid `APP_ENV` still fail-closes these paths to 404.
+
+## Firestore layout
+
+Environment isolation is preserved.
+
+```
+environments/{appEnv}/places/{placeId}
+environments/{appEnv}/runs/{runId}
+environments/{appEnv}/runs/{runId}/participants/{uid}
+environments/{appEnv}/athletes/{uid}/participations/{runId}
+```
+
+Why this layout:
+
+- Join/check-in is a direct document at `participants/{uid}` — natural uniqueness and cheap transactions.
+- Athlete history is a direct subcollection under the athlete — no collection-group query in Phase 3A.
+- The two participation documents are written in one transaction and store the same snapshot fields so fixture time-rolls do not erase history.
+- Lookup by Place is `runs.placeId` filtered in the service after a `sport` query. Phase 3A data volume is fixture-scale.
+- Future `AthleteConnection` can derive from shared `runId` values in athlete participation history without a follower graph.
+
+Discovery query: `runs` where `sport == basketball` (single-field, auto-indexed), then Python filters the time window and cancelled state. **No composite index is added.** A later geospatial/city+time query should add an index only when that query exists.
+
+City/region from the athlete profile is a **sort preference**, not a hard hide. Phase 3A does not implement radius search. This is intentional so labeled test runs remain findable while home-area matching is proven as a hint.
+
+## Integration boundary
+
+```
+External Provider (RecTrac, TeamSideline, municipal API, venue system)
+        → Adapter (future)
+        → SportBeacon Place / Run domain
+```
+
+Canonical Place and Run documents never require provider fields. `externalRefs` is optional and additive. Adapters may later upsert Places/Runs and attach `provider` + `externalId`. They must not become the primary key.
+
+Python `ProviderAdapter` protocol documents the future shape. No RecTrac (or other) network integration ships in this PR.
+
+## Explicit non-goals
+
+Athlete-to-athlete connections, participant social graph, group chat, messaging, Beacon Alerts, push notifications, live location / “on the way”, geofencing, maps/navigation, RecTrac/TeamSideline/municipal sync, media uploads, video AI, recruiting, public athlete profiles, followers, teams/leagues/tournaments, payments, wearables, organizer dashboards, fake live occupancy.
+
+Optional `runId` on manual basketball stats is **deferred to Phase 3B**. The current stat model remains valid without it. Linking stats to runs is useful but not required to prove Discover → Join → Check In → Persist.
+
+## Test strategy
+
+- Application-stack FastAPI tests with the in-memory sports-loop repository prove serialization, status calculation, timezone boundaries, discovery, join/check-in idempotency, ownership, lifecycle rejections, and history.
+- Runtime-gate tests prove invalid `APP_ENV` hides Phase 3 routes and staging allowlisting still hides legacy product APIs.
+- Firestore emulator tests prove environment-scoped persistence and continued client deny-all, including new collections.
+- Frontend Vitest tests prove Play rendering, join/check-in request guards, empty state, safe errors, and Phase 2B auth/profile/stats/insights/drills regressions.
+- Production remains health-only.
+
+## Product metrics preparation
+
+No analytics vendor is added. Domain events that a later telemetry layer can count:
+
+- run viewed (`GET /api/runs/{runId}`)
+- run joined (`POST .../join` creating or returning `going`)
+- athlete checked in (`POST .../check-in`)
+- repeat participation (history length per athlete)
+
+Structured logs record join/check-in failures with `runId` and reason. They do not record bearer tokens, credentials, full athlete records, or email.
+
+## Rollback
+
+Staging Cloud Run: point traffic at the previous ready revision of `sportbeacon-api-staging`. Frontend Preview is branch-scoped and disappears when the draft PR is closed. Production is not modified.

--- a/docs/phase-3b-athlete-connection.md
+++ b/docs/phase-3b-athlete-connection.md
@@ -1,0 +1,83 @@
+# Phase 3B candidate — Shared Play → Athlete Connection → Return
+
+Phase 3A proved `Place → Run → Join → Check In → Participation History`.
+
+Do not implement this document in the current PR.
+
+## Product intent
+
+After two athletes check in to the same Run, SportBeacon should be able to help them stay connected **because they played together**, not because they exchanged phone numbers.
+
+Candidate loop:
+
+`Play → Shared verified participation → Athlete Connection → Community return`
+
+## How athletes safely discover who they played with
+
+- Source of truth: overlapping `checked_in` (or later `completed`) participation on the same `runId`.
+- `going` without check-in is intent only and should not create a connection by itself.
+- Discovery should be opt-in. Phase 3A stores no roster for other athletes to read.
+- A later API might return **first name / display name only after both athletes consent**, never a dump of every participant UID to the browser.
+
+## Consent model
+
+Suggested states:
+
+1. `hidden` — default. Other athletes cannot see this athlete on a run.
+2. `visible_to_run` — athlete allows co-participants on that run to see a limited identity card.
+3. `open_to_connect` — athlete allows a connection request from a co-participant.
+
+Consent must be explicit, revocable, and per-run or per-athlete with a clear default of hidden. Server-authoritative. The browser cannot write another athlete's visibility.
+
+## Connection model
+
+`AthleteConnection` should be derived from shared verified participation:
+
+- `played_together` evidence: `runId`, `placeId`, `checkedInAt` pair
+- `requested` / `accepted` / `declined` / `blocked`
+- no generic follower graph
+- no phone-number exchange requirement
+
+Store under environment isolation, for example:
+
+`environments/{appEnv}/athleteConnections/{uidA}_{uidB}`
+
+with canonical unordered pair keys and server-verified UIDs.
+
+## Privacy implications
+
+- Rosters are sensitive. Do not expose emails, UIDs of strangers, or home areas.
+- Place venue coordinates are not athlete locations.
+- Still no continuous GPS.
+- Blocking and report/abuse paths are required before any social surface ships.
+- Direct client Firestore access remains denied.
+
+## Recurring run / community signals
+
+Once connections exist, later signals can include:
+
+- same Place + same weekday/time
+- repeat check-ins with the same athletes
+- "this community is active" without fake occupancy numbers
+
+These are derived metrics, not a separate social network product.
+
+## Notification requirements
+
+Phase 3B should decide, before building:
+
+- in-app only vs push
+- what events are allowed (connection request, run reminder for a Place the athlete already joined)
+- quiet hours and opt-in
+- no Beacon Alerts, group chat, or live location in the first connection slice
+
+## Recommended 3B slice
+
+The smallest next slice is:
+
+1. consent to be visible to co-participants on a run the athlete checked into;
+2. list those co-participants' display names;
+3. request/accept a connection;
+4. show connected athletes on return to Play.
+
+Stop before messaging, media, recruiting, and maps.

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,7 +1,7 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    // SportBeacon persists athlete profiles and stats only through FastAPI.
+    // SportBeacon persists athlete, Place, Run, and participation data only through FastAPI.
     // The browser uses Firebase Authentication and must not read or write Firestore.
     match /{document=**} {
       allow read, write: if false;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -114,8 +114,39 @@ code {
 
 .feature-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1rem;
+}
+
+.run-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.run-card,
+.run-detail {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1rem 1.1rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.run-card h3,
+.run-detail h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.test-data-label {
+  margin: 0;
+  color: var(--accent-2);
+  font-size: 0.85rem;
+  font-weight: 600;
 }
 
 .feature-card {
@@ -177,6 +208,16 @@ code {
   display: flex;
   flex-wrap: wrap;
   gap: 0.6rem;
+}
+
+.text-actions button:not(.linkish) {
+  border: 0;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  background: var(--accent-2);
+  color: #08101e;
+  font-weight: 700;
+  cursor: pointer;
 }
 
 button.linkish {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -80,14 +80,55 @@ async function fillBasketballStatForm(points = "8") {
   await userEvent.type(screen.getByLabelText("3P%"), "33");
 }
 
+function playEndpoints(
+  url: string,
+  method: string,
+  options?: {
+    runs?: Array<Record<string, unknown>>;
+    history?: Array<Record<string, unknown>>;
+    onJoin?: (runId: string) => Response | Promise<Response>;
+    onCheckIn?: (runId: string) => Response | Promise<Response>;
+  },
+): Response | Promise<Response> | null {
+  if (url.endsWith("/api/runs") && method === "GET") {
+    return jsonResponse({ items: options?.runs ?? [] });
+  }
+  if (url.endsWith("/api/me/participation") && method === "GET") {
+    return jsonResponse({ items: options?.history ?? [] });
+  }
+  const joinMatch = url.match(/\/api\/runs\/([^/]+)\/join$/);
+  if (joinMatch && method === "POST") {
+    if (options?.onJoin) {
+      return options.onJoin(joinMatch[1]);
+    }
+    return jsonResponse({ detail: "Not Found" }, 404);
+  }
+  const checkInMatch = url.match(/\/api\/runs\/([^/]+)\/check-in$/);
+  if (checkInMatch && method === "POST") {
+    if (options?.onCheckIn) {
+      return options.onCheckIn(checkInMatch[1]);
+    }
+    return jsonResponse({ detail: "Not Found" }, 404);
+  }
+  return null;
+}
+
 function workspaceFetch(options?: {
   onPostStat?: (init?: RequestInit) => Promise<Response> | Response;
   stats?: Array<{ statId: string; points: number; occurredAt: string }>;
+  runs?: Array<Record<string, unknown>>;
+  history?: Array<Record<string, unknown>>;
+  onJoin?: (runId: string) => Response | Promise<Response>;
+  onCheckIn?: (runId: string) => Response | Promise<Response>;
 }) {
   const stats = options?.stats ?? [];
   return vi.fn().mockImplementation(async (input: RequestInfo, init?: RequestInit) => {
     const url = String(input);
     const method = init?.method || "GET";
+    const play = playEndpoints(url, method, options);
+    if (play) {
+      return play;
+    }
     if (url.endsWith("/api/health")) {
       return healthOk();
     }
@@ -156,8 +197,13 @@ describe("SportBeaconAI athlete workspace", () => {
   it("transitions from signed-out to signed-in after sign-up", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockImplementation(async (input: RequestInfo) => {
+      vi.fn().mockImplementation(async (input: RequestInfo, init?: RequestInit) => {
         const url = String(input);
+        const method = init?.method || "GET";
+        const play = playEndpoints(url, method);
+        if (play) {
+          return play;
+        }
         if (url.endsWith("/api/health")) {
           return healthOk();
         }
@@ -183,8 +229,13 @@ describe("SportBeaconAI athlete workspace", () => {
     const { signOut } = await import("firebase/auth");
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockImplementation(async (input: RequestInfo) => {
+      vi.fn().mockImplementation(async (input: RequestInfo, init?: RequestInit) => {
         const url = String(input);
+        const method = init?.method || "GET";
+        const play = playEndpoints(url, method);
+        if (play) {
+          return play;
+        }
         if (url.endsWith("/api/health")) {
           return healthOk();
         }
@@ -269,6 +320,10 @@ describe("SportBeaconAI athlete workspace", () => {
     const fetchMock = vi.fn().mockImplementation(async (input: RequestInfo, init?: RequestInit) => {
       const url = String(input);
       const method = init?.method || "GET";
+      const play = playEndpoints(url, method);
+      if (play) {
+        return play;
+      }
       if (url.endsWith("/api/health")) {
         return healthOk();
       }
@@ -340,6 +395,10 @@ describe("SportBeaconAI athlete workspace", () => {
       vi.fn().mockImplementation(async (input: RequestInfo, init?: RequestInit) => {
         const url = String(input);
         const method = init?.method || "GET";
+        const play = playEndpoints(url, method);
+        if (play) {
+          return play;
+        }
         if (url.endsWith("/api/health")) {
           return healthOk();
         }
@@ -449,4 +508,188 @@ describe("SportBeaconAI athlete workspace", () => {
     expect(screen.getByLabelText("Points")).toHaveValue(8);
     expect(screen.getByLabelText("Played at")).toHaveValue("2024-04-01T20:00");
   });
+
+  it("renders active and upcoming runs with their places", async () => {
+    const fetchMock = workspaceFetch({ runs: sampleRuns() });
+    vi.stubGlobal("fetch", fetchMock);
+    await signInToWorkspace();
+    expect(await screen.findByTestId("run-card-test-run-basketball-active")).toHaveTextContent("TEST DATA — Lunch pickup run");
+    expect(screen.getByTestId("run-card-test-run-basketball-active")).toHaveTextContent("TEST DATA — Richmond Rec Gym");
+    expect(screen.getByTestId("run-card-test-run-basketball-active")).toHaveTextContent("Active");
+    expect(screen.getByTestId("run-card-test-run-basketball-upcoming")).toHaveTextContent("TEST DATA — Evening open gym");
+    expect(screen.getByTestId("run-card-test-run-basketball-upcoming")).toHaveTextContent("Upcoming");
+    expect(screen.getAllByText(/not a live municipal listing/i).length).toBeGreaterThan(0);
+  });
+
+  it("shows an intentional empty Play state", async () => {
+    vi.stubGlobal("fetch", workspaceFetch({ runs: [] }));
+    await signInToWorkspace();
+    expect(await screen.findByTestId("play-empty")).toHaveTextContent("No basketball runs are listed right now.");
+    expect(screen.getByTestId("play-state")).toHaveTextContent("does not invent live municipal schedules");
+  });
+
+  it("joins a run once and keeps the state after remount", async () => {
+    const runs = sampleRuns();
+    const history: Array<Record<string, unknown>> = [];
+    const fetchMock = workspaceFetch({
+      runs,
+      history,
+      onJoin: (runId) => {
+        const run = runs.find((item) => item.id === runId);
+        if (!run) {
+          return jsonResponse({ detail: "Run not found" }, 404);
+        }
+        run.myParticipation = { status: "going", joinedAt: "2026-08-15T18:00:00Z" };
+        history.splice(0, history.length, {
+          runId,
+          runTitle: run.title,
+          placeName: run.place.name,
+          startsAt: run.startsAt,
+          status: "going",
+          isTestData: true,
+        });
+        return jsonResponse(run);
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { unmount } = render(<App />);
+    await userEvent.type(screen.getByLabelText("Email"), "ada@example.com");
+    await userEvent.type(screen.getByLabelText("Password"), "secret1");
+    await userEvent.click(screen.getByRole("button", { name: "Sign in" }));
+    expect(await screen.findByText("TEST DATA — Evening open gym")).toBeInTheDocument();
+    await userEvent.click(screen.getAllByRole("button", { name: "View" })[1]);
+    await userEvent.click(screen.getByRole("button", { name: "I'm going" }));
+    expect(await screen.findByText("You're going")).toBeInTheDocument();
+    const joinCalls = fetchMock.mock.calls.filter(
+      ([url, init]) => String(url).endsWith("/join") && (init as RequestInit | undefined)?.method === "POST",
+    );
+    expect(joinCalls).toHaveLength(1);
+    unmount();
+    render(<App />);
+    expect(await screen.findByText("You're going")).toBeInTheDocument();
+    expect(await screen.findByTestId("history-item-test-run-basketball-upcoming")).toHaveTextContent("going");
+  });
+
+  it("ignores a second I'm going click while join is in flight", async () => {
+    const runs = sampleRuns();
+    let releaseJoin: () => void = () => undefined;
+    const gate = new Promise<void>((resolve) => {
+      releaseJoin = resolve;
+    });
+    const fetchMock = workspaceFetch({
+      runs,
+      onJoin: async (runId) => {
+        await gate;
+        const run = runs.find((item) => item.id === runId)!;
+        run.myParticipation = { status: "going", joinedAt: "2026-08-15T18:00:00Z" };
+        return jsonResponse(run);
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await signInToWorkspace();
+    await userEvent.click(screen.getAllByRole("button", { name: "View" })[1]);
+    const joinButton = screen.getByRole("button", { name: "I'm going" });
+    await userEvent.click(joinButton);
+    await userEvent.click(joinButton);
+    releaseJoin();
+    expect(await screen.findByText("You're going")).toBeInTheDocument();
+    const joinCalls = fetchMock.mock.calls.filter(
+      ([url, init]) => String(url).endsWith("/join") && (init as RequestInit | undefined)?.method === "POST",
+    );
+    expect(joinCalls).toHaveLength(1);
+  });
+
+  it("checks in once when eligible and guards a repeated click", async () => {
+    const runs = sampleRuns();
+    runs[0].myParticipation = { status: "going", joinedAt: "2026-08-15T17:30:00Z" };
+    let releaseCheckIn: () => void = () => undefined;
+    const gate = new Promise<void>((resolve) => {
+      releaseCheckIn = resolve;
+    });
+    const fetchMock = workspaceFetch({
+      runs,
+      onCheckIn: async (runId) => {
+        await gate;
+        const run = runs.find((item) => item.id === runId)!;
+        run.myParticipation = {
+          status: "checked_in",
+          joinedAt: "2026-08-15T17:30:00Z",
+          checkedInAt: "2026-08-15T18:01:00Z",
+        };
+        return jsonResponse(run);
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await signInToWorkspace();
+    await userEvent.click(screen.getAllByRole("button", { name: "View" })[0]);
+    const checkInButton = screen.getByRole("button", { name: "Check in" });
+    await userEvent.click(checkInButton);
+    await userEvent.click(checkInButton);
+    releaseCheckIn();
+    expect(await screen.findByTestId("checkin-complete")).toHaveTextContent("Checked in");
+    expect(screen.queryByRole("button", { name: "Check in" })).not.toBeInTheDocument();
+    const checkInCalls = fetchMock.mock.calls.filter(
+      ([url, init]) => String(url).endsWith("/check-in") && (init as RequestInit | undefined)?.method === "POST",
+    );
+    expect(checkInCalls).toHaveLength(1);
+  });
+
+  it("does not show Check in before the window and shows a safe join error", async () => {
+    const runs = sampleRuns();
+    const fetchMock = workspaceFetch({
+      runs,
+      onJoin: () => jsonResponse({ detail: "This run is not open to join" }, 409),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await signInToWorkspace();
+    await userEvent.click(screen.getAllByRole("button", { name: "View" })[1]);
+    expect(screen.queryByRole("button", { name: "Check in" })).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "I'm going" }));
+    expect(await screen.findByTestId("play-error")).toHaveTextContent("This run is not open to join");
+    expect(screen.queryByText(/traceback/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/firestore/i)).not.toBeInTheDocument();
+  });
 });
+
+function sampleRuns() {
+  return [
+    {
+      id: "test-run-basketball-active",
+      sport: "basketball",
+      title: "TEST DATA — Lunch pickup run",
+      startsAt: "2026-08-15T17:15:00Z",
+      endsAt: "2026-08-15T19:15:00Z",
+      status: "active",
+      isTestData: true,
+      checkInOpen: true,
+      place: {
+        id: "test-place-richmond-rec-gym",
+        name: "TEST DATA — Richmond Rec Gym",
+        city: "Richmond",
+        region: "VA",
+        country: "US",
+        isTestData: true,
+      },
+      myParticipation: null as { status: string; joinedAt: string; checkedInAt?: string } | null,
+    },
+    {
+      id: "test-run-basketball-upcoming",
+      sport: "basketball",
+      title: "TEST DATA — Evening open gym",
+      startsAt: "2026-08-15T21:00:00Z",
+      endsAt: "2026-08-15T23:00:00Z",
+      status: "upcoming",
+      isTestData: true,
+      checkInOpen: false,
+      place: {
+        id: "test-place-richmond-rec-gym",
+        name: "TEST DATA — Richmond Rec Gym",
+        city: "Richmond",
+        region: "VA",
+        country: "US",
+        isTestData: true,
+      },
+      myParticipation: null as { status: string; joinedAt: string; checkedInAt?: string } | null,
+    },
+  ];
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useCallback, useEffect, useRef, useState } from "react";
-import { apiFetch, ApiError, AuthRequiredError } from "./api/client";
+import { apiFetch, ApiError, AuthRequiredError, type AuthSession } from "./api/client";
 import { fetchHealth, getApiBaseUrl, type HealthPayload } from "./api/health";
 import { AuthProvider } from "./auth/AuthProvider";
 import { useAuth } from "./auth/context";
@@ -11,11 +11,57 @@ type ConnectionState =
   | { status: "error"; message: string };
 
 const ROADMAP = [
-  { id: "runs", title: "Runs & Matches", body: "Coming later. Activities will be anchored to real Places." },
-  { id: "places", title: "Places & courts", body: "Coming later. No live court or municipal data is shown here." },
   { id: "groups", title: "Groups & messaging", body: "Coming later. Private athlete identity is the foundation first." },
   { id: "matchmaking", title: "Matchmaking", body: "Prototype engine exists, but it is not part of this athlete workspace." },
 ] as const;
+
+type PlaceSummary = {
+  id: string;
+  name: string;
+  city: string;
+  region: string;
+  country: string;
+  entranceNotes?: string | null;
+  isTestData: boolean;
+};
+
+type MyParticipation = {
+  status: "going" | "checked_in" | "completed" | "withdrawn";
+  joinedAt: string;
+  checkedInAt?: string | null;
+};
+
+type RunView = {
+  id: string;
+  sport: string;
+  title: string;
+  startsAt: string;
+  endsAt: string;
+  status: "upcoming" | "active" | "completed" | "cancelled";
+  isTestData: boolean;
+  checkInOpen: boolean;
+  place: PlaceSummary;
+  myParticipation: MyParticipation | null;
+};
+
+type HistoryItem = {
+  runId: string;
+  runTitle: string;
+  placeName: string;
+  startsAt: string;
+  status: string;
+  isTestData: boolean;
+};
+
+function formatRunTime(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
 
 const emptyProfile = {
   displayName: "",
@@ -74,6 +120,8 @@ function AthleteWorkspace() {
         <nav aria-label="Primary">
           <a href="#status">Status</a>
           <a href="#account">Account</a>
+          <a href="#play">Play</a>
+          <a href="#history">History</a>
           <a href="#profile">Profile</a>
           <a href="#stats">Stats</a>
           <a href="#insights">Insights</a>
@@ -224,6 +272,7 @@ function SignedInPanels() {
   const statSavingRef = useRef(false);
   const [insightState, setInsightState] = useState("Insights use your persisted basketball stats.");
   const [drillState, setDrillState] = useState("Drills use your persisted profile skills.");
+  const [historyTick, setHistoryTick] = useState(0);
 
   const loadProfile = useCallback(async () => {
     try {
@@ -375,6 +424,8 @@ function SignedInPanels() {
 
   return (
     <>
+      <PlayPanel session={session} onParticipationChange={() => setHistoryTick((value) => value + 1)} />
+      <ParticipationHistory session={session} refreshKey={historyTick} />
       <section id="profile" className="health-panel">
         <div className="health-copy">
           <h2>Private athlete profile</h2>
@@ -524,6 +575,208 @@ function SignedInPanels() {
         <p data-testid="drill-state">{drillState}</p>
       </section>
     </>
+  );
+}
+
+function PlayPanel({
+  session,
+  onParticipationChange,
+}: {
+  session: AuthSession;
+  onParticipationChange: () => void;
+}) {
+  const [runs, setRuns] = useState<RunView[]>([]);
+  const [state, setState] = useState("Looking for basketball runs…");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [error, setError] = useState("");
+  const joinLock = useRef(false);
+  const checkInLock = useRef(false);
+
+  const loadRuns = useCallback(async () => {
+    try {
+      const data = await apiFetch<{ items: RunView[] }>("/api/runs", session);
+      setRuns(data.items);
+      setState(
+        data.items.length
+          ? "These are SportBeacon runs, not a live municipal schedule."
+          : "No basketball runs are listed right now. SportBeacon does not invent live municipal schedules.",
+      );
+      setError("");
+    } catch (caught: unknown) {
+      if (caught instanceof AuthRequiredError) {
+        setState("Sign in required.");
+        return;
+      }
+      setError(caught instanceof Error ? caught.message : "Unable to load runs");
+    }
+  }, [session]);
+
+  useEffect(() => {
+    void loadRuns();
+  }, [loadRuns]);
+
+  function replaceRun(updated: RunView) {
+    setRuns((current) => current.map((item) => (item.id === updated.id ? updated : item)));
+  }
+
+  async function joinRun(runId: string) {
+    if (joinLock.current) {
+      return;
+    }
+    joinLock.current = true;
+    setError("");
+    try {
+      const updated = await apiFetch<RunView>(`/api/runs/${runId}/join`, session, { method: "POST" });
+      replaceRun(updated);
+      onParticipationChange();
+    } catch (caught: unknown) {
+      setError(caught instanceof Error ? caught.message : "Unable to join this run");
+    } finally {
+      joinLock.current = false;
+    }
+  }
+
+  async function checkIn(runId: string) {
+    if (checkInLock.current) {
+      return;
+    }
+    checkInLock.current = true;
+    setError("");
+    try {
+      const updated = await apiFetch<RunView>(`/api/runs/${runId}/check-in`, session, { method: "POST" });
+      replaceRun(updated);
+      onParticipationChange();
+    } catch (caught: unknown) {
+      setError(caught instanceof Error ? caught.message : "Unable to check in");
+    } finally {
+      checkInLock.current = false;
+    }
+  }
+
+  const selected = runs.find((item) => item.id === selectedId) ?? null;
+
+  return (
+    <section id="play" className="health-panel">
+      <div className="health-copy">
+        <h2>Play today</h2>
+        <p>Find a basketball run, see where it is, and check in when you arrive.</p>
+      </div>
+      <p data-testid="play-state">{state}</p>
+      {error ? (
+        <p className="form-message" data-testid="play-error">
+          {error}
+        </p>
+      ) : null}
+      {runs.length === 0 ? (
+        <p data-testid="play-empty">No basketball runs are listed right now.</p>
+      ) : (
+        <ul className="run-list">
+          {runs.map((run) => (
+            <li key={run.id} className="run-card" data-testid={`run-card-${run.id}`}>
+              <div className="card-heading">
+                <h3>{run.title}</h3>
+                <span className="badge">{run.status === "active" ? "Active" : "Upcoming"}</span>
+              </div>
+              <p>
+                {run.place.name} · {run.place.city}, {run.place.region}
+              </p>
+              <p>
+                {formatRunTime(run.startsAt)} – {formatRunTime(run.endsAt)}
+              </p>
+              {run.isTestData ? <p className="test-data-label">Test data — not a live municipal listing</p> : null}
+              <p data-testid={`run-participation-${run.id}`}>
+                {run.myParticipation?.status === "checked_in"
+                  ? "Checked in"
+                  : run.myParticipation?.status === "going"
+                    ? "You're going"
+                    : "Not joined"}
+              </p>
+              <div className="text-actions">
+                <button type="button" onClick={() => setSelectedId(run.id)}>
+                  View
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+      {selected ? (
+        <div className="run-detail" data-testid="run-detail">
+          <h3>{selected.title}</h3>
+          <p>
+            {selected.place.name} · {selected.place.city}, {selected.place.region}
+          </p>
+          {selected.place.entranceNotes ? <p>{selected.place.entranceNotes}</p> : null}
+          <p>
+            {formatRunTime(selected.startsAt)} – {formatRunTime(selected.endsAt)}
+          </p>
+          <p>Status: {selected.status}</p>
+          {selected.myParticipation?.status === "checked_in" ? (
+            <p data-testid="checkin-complete">Checked in</p>
+          ) : (
+            <div className="text-actions">
+              {selected.myParticipation?.status === "going" ? null : (
+                <button type="button" onClick={() => void joinRun(selected.id)}>
+                  I&apos;m going
+                </button>
+              )}
+              {selected.checkInOpen ? (
+                <button type="button" onClick={() => void checkIn(selected.id)}>
+                  Check in
+                </button>
+              ) : null}
+            </div>
+          )}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function ParticipationHistory({
+  session,
+  refreshKey,
+}: {
+  session: AuthSession;
+  refreshKey: number;
+}) {
+  const [items, setItems] = useState<HistoryItem[]>([]);
+  const [state, setState] = useState("Your sports memory starts with runs you join.");
+
+  const loadHistory = useCallback(async () => {
+    try {
+      const data = await apiFetch<{ items: HistoryItem[] }>("/api/me/participation", session);
+      setItems(data.items);
+      setState(
+        data.items.length
+          ? `${data.items.length} recorded run${data.items.length === 1 ? "" : "s"}.`
+          : "No participation recorded yet.",
+      );
+    } catch (caught: unknown) {
+      setState(caught instanceof Error ? caught.message : "Unable to load participation history");
+    }
+  }, [session]);
+
+  useEffect(() => {
+    void loadHistory();
+  }, [loadHistory, refreshKey]);
+
+  return (
+    <section id="history" className="health-panel">
+      <div className="health-copy">
+        <h2>Participation history</h2>
+        <p>Runs you joined or checked into stay with your private athlete record.</p>
+      </div>
+      <p data-testid="history-state">{state}</p>
+      <ul className="stat-list">
+        {items.map((item) => (
+          <li key={item.runId} data-testid={`history-item-${item.runId}`}>
+            {item.runTitle} · {item.placeName} · {formatRunTime(item.startsAt)} · {item.status.replace("_", " ")}
+            {item.isTestData ? " · Test data" : ""}
+          </li>
+        ))}
+      </ul>
+    </section>
   );
 }
 

--- a/tests/test_firestore_emulator.py
+++ b/tests/test_firestore_emulator.py
@@ -45,13 +45,13 @@ def _http_status(url: str, token: str | None = None) -> int:
         return exc.code
 
 
-def _auth_emulator_id_token() -> str:
+def _auth_emulator_id_token(email: str = "rules-test@example.com") -> str:
     auth_host = os.getenv("FIREBASE_AUTH_EMULATOR_HOST", "127.0.0.1:9099")
     if not auth_host.startswith(("127.0.0.1", "localhost")):
         raise RuntimeError("Refusing to use a non-local Auth emulator host")
     payload = json.dumps(
         {
-            "email": "rules-test@example.com",
+            "email": email,
             "password": "test-password",
             "returnSecureToken": True,
         }
@@ -137,3 +137,95 @@ def test_backend_writes_stay_on_env_and_uid_path(monkeypatch):
         .get()
     )
     assert not other_uid.exists
+
+
+def test_anonymous_and_authenticated_direct_access_denied_for_places_and_runs():
+    token = _auth_emulator_id_token("places-rules-test@example.com")
+    for path in (
+        "environments/test/places/test-place-richmond-rec-gym",
+        "environments/test/runs/test-run-basketball-active",
+        "environments/test/runs/test-run-basketball-active/participants/user-a",
+    ):
+        assert _http_status(_firestore_url(path)) in {401, 403}
+        assert _http_status(_firestore_url(path), token=token) in {401, 403}
+
+
+def test_sports_loop_backend_writes_stay_on_env_path(monkeypatch):
+    monkeypatch.setenv("APP_ENV", "test")
+    from google.cloud import firestore
+
+    from backend.sports_loop_fixtures import ACTIVE_RUN_ID, PLACE_ID, ensure_sports_loop_fixtures
+    from backend.sports_loop_repository import FirestoreSportsLoopRepository
+    from backend.sports_loop_models import Participation
+
+    client = firestore.Client(project="sportbeacon-ai")
+    repo = FirestoreSportsLoopRepository(client=client, app_env="test")
+    now = datetime(2026, 8, 15, 18, 0, tzinfo=timezone.utc)
+    ensure_sports_loop_fixtures(repo, now)
+    place_snap = (
+        client.collection("environments")
+        .document("test")
+        .collection("places")
+        .document(PLACE_ID)
+        .get()
+    )
+    assert place_snap.exists
+    stray_place = (
+        client.collection("environments")
+        .document("production")
+        .collection("places")
+        .document(PLACE_ID)
+        .get()
+    )
+    assert not stray_place.exists
+    joined = repo.commit_join(
+        Participation(
+            uid="user-a",
+            runId=ACTIVE_RUN_ID,
+            status="going",
+            joinedAt=now,
+            runTitle="TEST DATA — Lunch pickup run",
+            placeId=PLACE_ID,
+            placeName="TEST DATA — Richmond Rec Gym",
+            sport="basketball",
+            startsAt=now,
+            isTestData=True,
+        )
+    )
+    assert joined.status == "going"
+    participant = (
+        client.collection("environments")
+        .document("test")
+        .collection("runs")
+        .document(ACTIVE_RUN_ID)
+        .collection("participants")
+        .document("user-a")
+        .get()
+    )
+    assert participant.exists
+    history = (
+        client.collection("environments")
+        .document("test")
+        .collection("athletes")
+        .document("user-a")
+        .collection("participations")
+        .document(ACTIVE_RUN_ID)
+        .get()
+    )
+    assert history.exists
+    again = repo.commit_join(
+        Participation(
+            uid="user-a",
+            runId=ACTIVE_RUN_ID,
+            status="going",
+            joinedAt=now,
+            runTitle="changed",
+            placeId=PLACE_ID,
+            placeName="changed",
+            sport="basketball",
+            startsAt=now,
+            isTestData=True,
+        )
+    )
+    assert again.runTitle == joined.runTitle
+

--- a/tests/test_production_api_safety.py
+++ b/tests/test_production_api_safety.py
@@ -187,6 +187,9 @@ def test_production_authenticated_profile_routes_stay_closed_when_flag_false(mon
     client = _production_client(monkeypatch)
     assert client.get("/api/me").status_code == 404
     assert client.get("/api/me/profile").status_code == 404
+    assert client.get("/api/runs").status_code == 404
+    assert client.post("/api/runs/test-run-basketball-active/join").status_code == 404
+    assert client.get("/api/me/participation").status_code == 404
 
 
 def test_production_ignores_product_route_flag_without_auth(monkeypatch):

--- a/tests/test_runtime_fail_closed.py
+++ b/tests/test_runtime_fail_closed.py
@@ -23,7 +23,7 @@ PERMISSIVE_FLAGS = {
     "ENABLE_API_DOCS": "true",
     "ENABLE_EXPERIMENTAL_ROUTES": "true",
 }
-HIDDEN_PATHS = ("/api/me", "/api/drills/recommend", "/docs", "/openapi.json")
+HIDDEN_PATHS = ("/api/me", "/api/drills/recommend", "/docs", "/openapi.json", "/api/runs")
 STAGING_ORIGIN = "https://sportbeacon-ai.vercel.app"
 PREVIEW_ORIGIN = (
     "https://sportbeacon-ai-git-feat-firebase-au-30ec74-trondurells-projects.vercel.app"
@@ -53,6 +53,7 @@ def _assert_health_closed_surface(client: TestClient) -> None:
     assert "firebase" not in health.text.lower()
     assert client.get("/api/me").status_code == 404
     assert client.post("/api/drills/recommend", json=DRILL_PAYLOAD).status_code == 404
+    assert client.get("/api/runs").status_code == 404
     assert client.get("/docs").status_code == 404
     assert client.get("/openapi.json").status_code == 404
 
@@ -119,6 +120,7 @@ def test_recognized_development_keeps_controlled_local_behavior(monkeypatch):
     )
     assert closed.post("/api/drills/recommend", json=DRILL_PAYLOAD).status_code == 404
     assert closed.get("/api/me").status_code == 404
+    assert closed.get("/api/runs").status_code == 404
     assert closed.get("/docs").status_code == 404
     auth_only = _client(
         monkeypatch,
@@ -129,6 +131,7 @@ def test_recognized_development_keeps_controlled_local_behavior(monkeypatch):
         },
     )
     assert auth_only.get("/api/me").status_code == 401
+    assert auth_only.get("/api/runs").status_code == 401
     assert auth_only.post("/api/drills/recommend", json=DRILL_PAYLOAD).status_code == 404
 
 
@@ -146,6 +149,7 @@ def test_recognized_test_keeps_intentional_product_behavior(monkeypatch):
         },
     )
     assert gated.get("/api/me").status_code == 401
+    assert gated.get("/api/runs").status_code == 401
     assert gated.post("/api/drills/recommend", json=DRILL_PAYLOAD).status_code == 404
 
 
@@ -162,6 +166,7 @@ def test_recognized_staging_hides_legacy_even_when_product_flag_true(monkeypatch
     )
     assert client.get("/api/health").status_code == 200
     assert client.get("/api/me").status_code == 401
+    assert client.get("/api/runs").status_code == 401
     assert client.post("/api/drills/recommend", json=DRILL_PAYLOAD).status_code == 404
     assert client.get("/docs").status_code == 404
     assert client.get("/openapi.json").status_code == 404
@@ -181,6 +186,7 @@ def test_recognized_production_hides_legacy_even_when_flags_true(monkeypatch):
     )
     assert client.get("/api/health").status_code == 200
     assert client.get("/api/me").status_code == 401
+    assert client.get("/api/runs").status_code == 401
     assert client.post("/api/drills/recommend", json=DRILL_PAYLOAD).status_code == 404
     assert client.get("/docs").status_code == 404
     assert client.get("/openapi.json").status_code == 404
@@ -211,6 +217,10 @@ def test_staging_preflight_allows_enabled_me_and_hides_disabled_surfaces(monkeyp
     allowed = _preflight(client, "/api/me", STAGING_ORIGIN)
     assert allowed.status_code in {200, 204}
     assert allowed.headers.get("access-control-allow-origin") == STAGING_ORIGIN
+
+    runs = _preflight(client, "/api/runs", STAGING_ORIGIN)
+    assert runs.status_code in {200, 204}
+    assert runs.headers.get("access-control-allow-origin") == STAGING_ORIGIN
 
     preview = _preflight(client, "/api/me", PREVIEW_ORIGIN)
     assert preview.status_code in {200, 204}

--- a/tests/test_sports_loop_api.py
+++ b/tests/test_sports_loop_api.py
@@ -1,0 +1,351 @@
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from backend.api import create_app
+from backend.athlete_repository import InMemoryAthleteRepository
+from backend.sports_loop_fixtures import (
+    ACTIVE_RUN_ID,
+    CANCELLED_RUN_ID,
+    COMPLETED_RUN_ID,
+    PLACE_ID,
+    UPCOMING_RUN_ID,
+    build_test_place,
+    build_test_runs,
+    ensure_sports_loop_fixtures,
+)
+from backend.sports_loop_models import Place, Run
+from backend.sports_loop_repository import InMemorySportsLoopRepository
+from backend.sports_loop_service import CHECK_IN_LEAD, compute_run_status
+
+NOW = datetime(2026, 8, 15, 18, 0, tzinfo=timezone.utc)
+
+
+class FakeVerifier:
+    def __init__(self) -> None:
+        self.uid_for_token = {
+            "header.user-a.sig": "user-a",
+            "header.user-b.sig": "user-b",
+        }
+
+    def verify_id_token(self, token: str) -> str:
+        uid = self.uid_for_token.get(token)
+        if not uid:
+            raise ValueError("unknown")
+        return uid
+
+
+def _auth(token: str = "header.user-a.sig") -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _app_client(monkeypatch, extra=None, now=NOW):
+    monkeypatch.setenv("APP_ENV", "test")
+    monkeypatch.setenv("ENABLE_SPORTS_LOOP_FIXTURES", "false")
+    for key, value in (extra or {}).items():
+        if value is None:
+            monkeypatch.delenv(key, raising=False)
+        else:
+            monkeypatch.setenv(key, value)
+    app = create_app()
+    app.state.token_verifier = FakeVerifier()
+    app.state.athlete_repository = InMemoryAthleteRepository()
+    repo = InMemorySportsLoopRepository()
+    app.state.sports_loop_repository = repo
+    app.state.sports_loop_clock = lambda: now
+    return TestClient(app), repo
+
+
+def _seed(repo: InMemorySportsLoopRepository, now=NOW) -> None:
+    ensure_sports_loop_fixtures(repo, now)
+
+
+def test_place_and_run_serialization_round_trip(monkeypatch):
+    _, repo = _app_client(monkeypatch)
+    place = build_test_place(NOW)
+    run = build_test_runs(NOW)[0]
+    stored_place = Place.model_validate(repo.upsert_place(place).model_dump())
+    stored_run = Run.model_validate(repo.upsert_run(run).model_dump())
+    assert stored_place.id == PLACE_ID
+    assert stored_place.isTestData is True
+    assert stored_place.city == "Richmond"
+    assert stored_run.sport == "basketball"
+    assert stored_run.placeId == PLACE_ID
+    assert stored_run.startsAt.tzinfo is not None
+
+
+def test_run_status_boundaries_use_server_utc(monkeypatch):
+    start = NOW
+    end = NOW + timedelta(hours=2)
+    run = Run(
+        id="boundary-run-status-1",
+        sport="basketball",
+        placeId=PLACE_ID,
+        title="Boundary",
+        startsAt=start,
+        endsAt=end,
+        status="scheduled",
+        createdBy="test",
+        createdAt=NOW,
+        updatedAt=NOW,
+    )
+    assert compute_run_status(run, start - timedelta(seconds=1)) == "upcoming"
+    assert compute_run_status(run, start) == "active"
+    assert compute_run_status(run, end) == "active"
+    assert compute_run_status(run, end + timedelta(seconds=1)) == "completed"
+    cancelled = run.model_copy(update={"status": "cancelled"})
+    assert compute_run_status(cancelled, start) == "cancelled"
+
+
+def test_timezone_aware_comparison_does_not_use_naive_local_clock(monkeypatch):
+    eastern = datetime(2026, 8, 15, 14, 0, tzinfo=timezone(timedelta(hours=-4)))
+    run = Run(
+        id="timezone-run-status",
+        sport="basketball",
+        placeId=PLACE_ID,
+        title="TZ",
+        startsAt=NOW,
+        endsAt=NOW + timedelta(hours=1),
+        status="scheduled",
+        createdBy="test",
+        createdAt=NOW,
+        updatedAt=NOW,
+    )
+    assert eastern.astimezone(timezone.utc) == NOW
+    assert compute_run_status(run, eastern) == "active"
+
+
+def test_unauthenticated_sports_loop_operations_fail(monkeypatch):
+    client, repo = _app_client(monkeypatch)
+    _seed(repo)
+    assert client.get("/api/runs").status_code == 401
+    assert client.get(f"/api/runs/{ACTIVE_RUN_ID}").status_code == 401
+    assert client.post(f"/api/runs/{ACTIVE_RUN_ID}/join").status_code == 401
+    assert client.post(f"/api/runs/{ACTIVE_RUN_ID}/check-in").status_code == 401
+    assert client.get("/api/me/participation").status_code == 401
+
+
+def test_discovery_returns_active_and_upcoming_with_place(monkeypatch):
+    client, repo = _app_client(monkeypatch)
+    _seed(repo)
+    response = client.get("/api/runs", headers=_auth())
+    assert response.status_code == 200, response.text
+    body = response.json()
+    ids = {item["id"] for item in body["items"]}
+    assert ACTIVE_RUN_ID in ids
+    assert UPCOMING_RUN_ID in ids
+    assert COMPLETED_RUN_ID not in ids
+    assert CANCELLED_RUN_ID not in ids
+    active = next(item for item in body["items"] if item["id"] == ACTIVE_RUN_ID)
+    assert active["status"] == "active"
+    assert active["place"]["name"].startswith("TEST DATA")
+    assert active["place"]["city"] == "Richmond"
+    assert active["isTestData"] is True
+    assert active["myParticipation"] is None
+    upcoming = next(item for item in body["items"] if item["id"] == UPCOMING_RUN_ID)
+    assert upcoming["status"] == "upcoming"
+
+
+def test_join_is_idempotent_and_persists(monkeypatch):
+    client, repo = _app_client(monkeypatch)
+    _seed(repo)
+    first = client.post(f"/api/runs/{UPCOMING_RUN_ID}/join", headers=_auth())
+    second = client.post(f"/api/runs/{UPCOMING_RUN_ID}/join", headers=_auth())
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert first.json()["myParticipation"]["status"] == "going"
+    assert second.json()["myParticipation"]["joinedAt"] == first.json()["myParticipation"]["joinedAt"]
+    stored = repo.get_participation(UPCOMING_RUN_ID, "user-a")
+    assert stored is not None
+    assert stored.status == "going"
+    listed = client.get("/api/runs", headers=_auth())
+    upcoming = next(item for item in listed.json()["items"] if item["id"] == UPCOMING_RUN_ID)
+    assert upcoming["myParticipation"]["status"] == "going"
+    history = client.get("/api/me/participation", headers=_auth())
+    assert history.status_code == 200
+    assert history.json()["items"][0]["runId"] == UPCOMING_RUN_ID
+    assert history.json()["items"][0]["placeName"].startswith("TEST DATA")
+
+
+def test_duplicate_join_does_not_create_second_record(monkeypatch):
+    client, repo = _app_client(monkeypatch)
+    _seed(repo)
+    client.post(f"/api/runs/{ACTIVE_RUN_ID}/join", headers=_auth())
+    client.post(f"/api/runs/{ACTIVE_RUN_ID}/join", headers=_auth())
+    matches = [
+        item
+        for item in repo.list_participations("user-a")
+        if item.runId == ACTIVE_RUN_ID
+    ]
+    assert len(matches) == 1
+
+
+def test_athlete_cannot_mutate_another_athletes_participation(monkeypatch):
+    client, repo = _app_client(monkeypatch)
+    _seed(repo)
+    joined = client.post(f"/api/runs/{ACTIVE_RUN_ID}/join", headers=_auth("header.user-a.sig"))
+    assert joined.status_code == 200
+    impersonate = client.post(
+        f"/api/runs/{ACTIVE_RUN_ID}/join",
+        headers=_auth("header.user-a.sig"),
+        json={"uid": "user-b"},
+    )
+    assert impersonate.status_code == 400
+    other = client.get(f"/api/runs/{ACTIVE_RUN_ID}", headers=_auth("header.user-b.sig"))
+    assert other.status_code == 200
+    assert other.json()["myParticipation"] is None
+    other_join = client.post(f"/api/runs/{ACTIVE_RUN_ID}/join", headers=_auth("header.user-b.sig"))
+    assert other_join.status_code == 200
+    assert repo.get_participation(ACTIVE_RUN_ID, "user-a").status == "going"
+    assert repo.get_participation(ACTIVE_RUN_ID, "user-b").status == "going"
+    history_b = client.get("/api/me/participation", headers=_auth("header.user-b.sig"))
+    assert all(item["runId"] != "user-a" for item in history_b.json()["items"])
+    assert history_b.json()["items"][0]["status"] == "going"
+
+
+def test_unknown_run_cannot_be_joined_or_checked_in(monkeypatch):
+    client, _ = _app_client(monkeypatch)
+    missing = "missing-run-id-xx"
+    assert client.get(f"/api/runs/{missing}", headers=_auth()).status_code == 404
+    assert client.post(f"/api/runs/{missing}/join", headers=_auth()).status_code == 404
+    assert client.post(f"/api/runs/{missing}/check-in", headers=_auth()).status_code == 404
+
+
+def test_completed_and_cancelled_runs_cannot_be_joined(monkeypatch):
+    client, repo = _app_client(monkeypatch)
+    _seed(repo)
+    completed = client.post(f"/api/runs/{COMPLETED_RUN_ID}/join", headers=_auth())
+    cancelled = client.post(f"/api/runs/{CANCELLED_RUN_ID}/join", headers=_auth())
+    assert completed.status_code == 409
+    assert cancelled.status_code == 409
+    assert "traceback" not in completed.text.lower()
+    assert "firestore" not in completed.text.lower()
+
+
+def test_check_in_window_and_idempotency(monkeypatch):
+    client, repo = _app_client(monkeypatch)
+    _seed(repo)
+    too_early = client.post(f"/api/runs/{UPCOMING_RUN_ID}/check-in", headers=_auth())
+    assert too_early.status_code == 409
+    first = client.post(f"/api/runs/{ACTIVE_RUN_ID}/check-in", headers=_auth())
+    second = client.post(f"/api/runs/{ACTIVE_RUN_ID}/check-in", headers=_auth())
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200
+    assert first.json()["myParticipation"]["status"] == "checked_in"
+    assert second.json()["myParticipation"]["checkedInAt"] == first.json()["myParticipation"]["checkedInAt"]
+    stored = repo.get_participation(ACTIVE_RUN_ID, "user-a")
+    assert stored is not None
+    assert stored.checkedInAt is not None
+    history = client.get("/api/me/participation", headers=_auth())
+    assert history.json()["items"][0]["status"] == "checked_in"
+
+
+def test_check_in_opens_at_lead_time(monkeypatch):
+    lead_now = NOW + timedelta(hours=3) - CHECK_IN_LEAD
+    client, repo = _app_client(monkeypatch, now=lead_now)
+    _seed(repo)
+    # Fixtures rebuild relative to lead_now, so re-seed an upcoming run with absolute times.
+    place = build_test_place(NOW)
+    repo.upsert_place(place)
+    upcoming = Run(
+        id="lead-time-run-checkin",
+        sport="basketball",
+        placeId=PLACE_ID,
+        title="Lead window",
+        startsAt=NOW + timedelta(hours=3),
+        endsAt=NOW + timedelta(hours=5),
+        status="scheduled",
+        createdBy="test",
+        createdAt=NOW,
+        updatedAt=NOW,
+    )
+    repo.upsert_run(upcoming)
+    allowed = client.post("/api/runs/lead-time-run-checkin/check-in", headers=_auth())
+    assert allowed.status_code == 200, allowed.text
+    assert allowed.json()["myParticipation"]["status"] == "checked_in"
+
+
+def test_check_in_rejected_after_end(monkeypatch):
+    client, repo = _app_client(monkeypatch, now=NOW + timedelta(minutes=76))
+    place = build_test_place(NOW)
+    repo.upsert_place(place)
+    run = Run(
+        id="ended-run-check-in1",
+        sport="basketball",
+        placeId=PLACE_ID,
+        title="Ended",
+        startsAt=NOW - timedelta(minutes=45),
+        endsAt=NOW + timedelta(minutes=75),
+        status="scheduled",
+        createdBy="test",
+        createdAt=NOW,
+        updatedAt=NOW,
+    )
+    repo.upsert_run(run)
+    response = client.post("/api/runs/ended-run-check-in1/check-in", headers=_auth())
+    assert response.status_code == 409
+
+
+def test_join_then_check_in_history_survives(monkeypatch):
+    client, repo = _app_client(monkeypatch)
+    _seed(repo)
+    client.post(f"/api/runs/{ACTIVE_RUN_ID}/join", headers=_auth())
+    client.post(f"/api/runs/{ACTIVE_RUN_ID}/check-in", headers=_auth())
+    history = client.get("/api/me/participation", headers=_auth())
+    assert history.status_code == 200
+    item = history.json()["items"][0]
+    assert item["status"] == "checked_in"
+    assert item["runTitle"].startswith("TEST DATA")
+
+
+def test_fixtures_are_labeled_test_data(monkeypatch):
+    client, _ = _app_client(
+        monkeypatch,
+        extra={"ENABLE_SPORTS_LOOP_FIXTURES": "true"},
+    )
+    response = client.get("/api/runs", headers=_auth())
+    assert response.status_code == 200
+    assert response.json()["items"]
+    assert all(item["isTestData"] is True for item in response.json()["items"])
+    assert all("TEST DATA" in item["title"] for item in response.json()["items"])
+
+
+def test_staging_allowlist_exposes_authenticated_runs_and_hides_legacy(monkeypatch):
+    client, repo = _app_client(
+        monkeypatch,
+        extra={
+            "APP_ENV": "staging",
+            "ENABLE_PRODUCT_ROUTES": "false",
+            "ENABLE_AUTHENTICATED_PROFILE_ROUTES": "true",
+            "ENABLE_SPORTS_LOOP_FIXTURES": "false",
+            "ENABLE_EXPERIMENTAL_ROUTES": "false",
+            "ENABLE_API_DOCS": "false",
+            "CORS_ALLOW_ORIGINS": "https://sportbeacon-ai.vercel.app",
+        },
+    )
+    _seed(repo)
+    assert client.get("/api/runs").status_code == 401
+    listed = client.get("/api/runs", headers=_auth())
+    assert listed.status_code == 200, listed.text
+    assert client.post("/api/drills/recommend", json={"user_id": "x"}).status_code == 404
+    preflight = client.options(
+        f"/api/runs/{ACTIVE_RUN_ID}/join",
+        headers={
+            "Origin": "https://sportbeacon-ai.vercel.app",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "authorization,content-type",
+        },
+    )
+    assert preflight.status_code in {200, 204}
+    assert preflight.headers.get("access-control-allow-origin") == "https://sportbeacon-ai.vercel.app"
+
+
+def test_invalid_app_env_hides_sports_loop_routes(monkeypatch):
+    monkeypatch.delenv("APP_ENV", raising=False)
+    monkeypatch.setenv("ENABLE_AUTHENTICATED_PROFILE_ROUTES", "true")
+    monkeypatch.setenv("ENABLE_PRODUCT_ROUTES", "true")
+    client = TestClient(create_app())
+    assert client.get("/api/health").status_code == 200
+    assert client.get("/api/runs").status_code == 404
+    assert client.post(f"/api/runs/{ACTIVE_RUN_ID}/join", headers=_auth()).status_code == 404
+    assert client.get("/api/me/participation", headers=_auth()).status_code == 404


### PR DESCRIPTION
## User outcome

An authenticated athlete can open SportBeacon, see labeled basketball test Runs and their Places, join with `I'm going`, check in during the allowed window, refresh, and retain that participation in History without manual Firestore editing.

## Architecture

`Place → Run → Participation`, with CheckIn represented by `status=checked_in` plus `checkedInAt` on the single participation record per athlete+run.

Future athlete connections are designed to derive from shared verified participation. They are not implemented here. See `docs/phase-3-core-sports-loop.md` and `docs/phase-3b-athlete-connection.md`.

## Privacy

- Athlete UID comes from the verified Firebase token, never the request body.
- Participation is private to the owning athlete in Phase 3A. No participant roster is exposed.
- Places may include public venue coordinates; exact athlete home addresses are not stored.
- No continuous GPS, background location, or movement trails.
- Browser Firestore remains deny-all; Places/Runs/Participation are server-mediated.

## Data model

- `environments/{appEnv}/places/{placeId}`
- `environments/{appEnv}/runs/{runId}`
- `environments/{appEnv}/runs/{runId}/participants/{uid}`
- `environments/{appEnv}/athletes/{uid}/participations/{runId}`

## API

All Phase 3A routes require a verified bearer token and are gated by the existing authenticated route boundary. Invalid `APP_ENV` fail-closes to 404.

- `GET /api/runs`
- `GET /api/runs/{runId}`
- `POST /api/runs/{runId}/join`
- `POST /api/runs/{runId}/check-in`
- `GET /api/me/participation`

## Staging deployment

- Deployed feature SHA: `53be2f6065af9d5d9c068d9bd0276cbc5fc8faba`
- Cloud Build: `58f250bb-d4a5-4dbc-a570-c855861d22a2` — SUCCESS
- Revision: `sportbeacon-api-staging-00004-fcw` — Ready / ContainerHealthy
- Traffic: 100%
- Rollback revision: `sportbeacon-api-staging-00003-8p6`
- Runtime identity: `sportbeacon-api-runtime@sportbeacon-ai.iam.gserviceaccount.com`
- `ENABLE_SPORTS_LOOP_FIXTURES=true` on staging only
- Health: `GET /api/health` → 200

## Route verification

- unauthenticated `GET /api/runs` → 401
- unauthenticated `GET /api/me/participation` → 401
- legacy `POST /api/drills/recommend` → 404
- `GET /docs` → 404
- `GET /openapi.json` → 404

## CORS

The Phase 3A Vercel Preview origin is allowed for the authenticated sports-loop routes. Unrelated origins are not reflected. Disabled legacy preflights remain 404. CORS was not loosened to `*`.

## Fixtures

Staging idempotently upserts clearly labeled TEST DATA Place/Runs on authenticated discovery. Production cannot enable these fixtures under the production runtime policy. Example fixture: `TEST DATA — Richmond Rec Gym`.

## Tests / CI

Feature SHA `53be2f6065af9d5d9c068d9bd0276cbc5fc8faba`:

- Frontend type-check: passed
- Frontend lint: passed
- Frontend tests: **19 passed**
- Frontend production build: passed
- Python tests: **109 passed, 5 skipped** without emulator
- Firestore emulator tests: **5 passed**
- Legacy backend `npm ci`: passed
- Secret/tracked-file scans: passed

Required GitHub jobs:

- `frontend (18.x)` — success
- `python` — success
- `legacy-node-backend (install only) (18.x)` — success

CI run: `31910710380`

## Final Phase 3A Preview Acceptance

Human Preview acceptance **PASSED** on August 18, 2026 against feature SHA `53be2f6065af9d5d9c068d9bd0276cbc5fc8faba` and staging revision `sportbeacon-api-staging-00004-fcw`.

Verified end to end:

- [x] Play loads without `Failed to fetch`
- [x] labeled TEST DATA Run appears
- [x] Place appears
- [x] Run status/time appears
- [x] `I'm going` joins the Run
- [x] joined state survives refresh
- [x] active Run allows Check In
- [x] checked-in state survives refresh
- [x] Participation History retains the Run
- [x] existing Profile functionality still loads
- [x] existing Stats functionality still loads
- [x] existing Insights functionality still works
- [x] no blocking browser console/network error was observed

Phase 3A user outcome proven:

`Discover → Join → Check In → Persist`

## Preview

`https://sportbeacon-ai-git-feat-mvp-core-sp-69eebe-trondurells-projects.vercel.app`

## Non-goals / deferred

Athlete connections, participant rosters, messaging, Beacon Alerts, push notifications, live location, geofencing, maps, RecTrac/TeamSideline/municipal sync, media/video AI, recruiting, public profiles, followers, teams/leagues/tournaments, payments, wearables, and organizer dashboards.

## Rollback

Staging rollback:

`gcloud run services update-traffic sportbeacon-api-staging --to-revisions sportbeacon-api-staging-00003-8p6=100 --project sportbeacon-ai --region us-east1`

## Production

Production remains unchanged. Phase 3A has not been deployed to production.

`Phase 3A preview acceptance passed.`