### PR TITLE
chore: require explicit Vercel production promotion

### DIFF
--- a/README_OPTION_B_TEMP
+++ b/README_OPTION_B_TEMP
@@ -1,0 +1,1 @@
+temporary

--- a/README_OPTION_B_TEMP
+++ b/README_OPTION_B_TEMP
@@ -1,1 +1,0 @@
-temporary

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -1,0 +1,77 @@
+# SportBeaconAI Release Policy
+
+## Policy
+
+SportBeaconAI uses an explicit production-promotion workflow.
+
+Merging accepted engineering work to `main` establishes the trusted code baseline, but it does **not** by itself authorize a Vercel Production release.
+
+The intended path is:
+
+`feature branch → CI → Vercel Preview → Cloud Run staging → human acceptance → main → explicit production candidate → explicit promotion`
+
+## Vercel Git behavior
+
+`vercel.json` disables automatic Git deployments for `main` only. Unspecified feature branches remain eligible for Vercel Preview deployments.
+
+This keeps Preview deployments available for pull-request acceptance while preventing ordinary merges to `main` from automatically replacing the public production frontend.
+
+## Production release gate
+
+A frontend production release requires an explicit release decision after all of the following are true:
+
+1. The accepted pull request is merged.
+2. `main` is healthy and protected checks are green.
+3. The intended backend production capability is compatible with the frontend being released.
+4. Production configuration and IAM have been reviewed for the release.
+5. A production candidate is built from the verified `main` checkout.
+6. The candidate is inspected and smoke-tested before promotion.
+
+## Recommended release procedure
+
+From a clean repository checkout:
+
+```powershell
+git switch main
+git pull --ff-only
+git rev-parse HEAD
+```
+
+Confirm the SHA is the intended release SHA.
+
+Create a candidate deployment without changing production traffic:
+
+```powershell
+vercel deploy
+```
+
+Inspect and test the returned candidate URL. Useful checks include:
+
+```powershell
+vercel inspect <candidate-url>
+vercel logs --deployment <candidate-url> --level error --limit 50
+```
+
+Only after acceptance, explicitly promote the exact candidate:
+
+```powershell
+vercel promote <candidate-url> --yes
+vercel promote status
+```
+
+Then verify the public production deployment and application behavior.
+
+## Rollback
+
+If a promoted frontend release causes a regression, use the established Vercel rollback process to return production traffic to the last known-good deployment. Record the rollback deployment and reason in the relevant release record or pull request.
+
+Backend Cloud Run production remains a separate release gate. Promoting a Vercel frontend does not authorize Cloud Run production deployment, Firebase policy changes, IAM changes, or production data migrations.
+
+## Rules
+
+- Do not use a merge to `main` as implicit production authorization.
+- Do not promote a Vercel Preview whose backend dependencies are unavailable in production.
+- Do not expose staging TEST DATA fixtures in production.
+- Do not bypass CI, branch protection, or human acceptance gates.
+- Do not create service-account key files for deployment automation.
+- Prefer keyless authenticated tooling and existing platform identities.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    }
+  }
+}


### PR DESCRIPTION
## Goal

Adopt the SportBeaconAI Option B release policy: merging accepted work to `main` establishes the trusted engineering baseline but does not automatically publish a new Vercel Production frontend.

## Change

- Add `vercel.json` with `git.deploymentEnabled.main=false`.
- Keep unspecified feature branches eligible for Vercel Preview deployments.
- Add `docs/release-policy.md` describing the explicit release path:
  `feature → CI → Preview → staging → human acceptance → main → candidate → explicit promote`.
- Keep Cloud Run production as a separate release gate.

## Why

PR #19 demonstrated that Vercel Git Integration automatically deployed the Phase 3A frontend when the accepted branch was squash-merged to `main`, while the Cloud Run production API intentionally remained health-only. This policy prevents future frontend/backend release drift.

## Validation required

- Verify Vercel accepts the `git.deploymentEnabled` configuration.
- Verify this branch still receives a Preview deployment.
- Verify required repository CI remains green.
- After merge, verify the `main` push does **not** create a new automatic Vercel Production deployment.
- Do not intentionally modify the current production deployment as part of this PR.

## Production release process after this PR

Build a candidate explicitly from verified `main`, inspect/test it, then use an explicit `vercel promote <candidate-url> --yes` release action. Backend Cloud Run production promotion remains independently controlled.

Draft until the release-control behavior is verified.