### PR TITLE
fix: permit safe reconnection after later shared play

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Included:
 - Per-run connection visibility consent that starts hidden for every athlete
 - "People you played with" limited to co-players from a run both athletes checked into
 - Private connection requests, acceptance, decline, removal, blocking, and safety reporting
+- Reconnection after a decline or a removal, allowed only once both athletes check into a later run
+  together, and never after a block
 - Labeled development/staging test Place and Runs (not live municipal data)
 - Live FastAPI health check with loading, connected, and error/retry states
 - Disabled roadmap labels for later modules
@@ -157,7 +159,7 @@ npx -y firebase-tools@latest emulators:exec --only auth,firestore --project spor
 
 - The athlete workspace authenticates with email/password and persists a private profile, basketball stats, and Run participation through FastAPI.
 - Play Today uses labeled test Place/Run fixtures in development and staging. Those are not live municipal listings.
-- Private athlete connections come only from runs both athletes checked into, are hidden by default, and never exchange contact details. See `docs/phase-3b-athlete-connections.md`.
+- Private athlete connections come only from runs both athletes checked into, are hidden by default, and never exchange contact details. A declined or removed pair can start over only after a later run they both checked into; a block is permanent. See `docs/phase-3b-athlete-connections.md`.
 - Groups, Messaging, and Matchmaking remain roadmap work. See `docs/phase-3-core-sports-loop.md` and `docs/phase-3b-athlete-connection.md`.
 - Coach, highlight, media, and extended-schedule paths remain incomplete and are not started with the shell.
 - Historical `logs/` files were removed from Git tracking. Local copies may still exist. Do not commit Firebase config values or service-account keys.

--- a/backend/connection_models.py
+++ b/backend/connection_models.py
@@ -29,6 +29,9 @@ SafetyReasonCode = Literal[
 DEFAULT_CONNECTION_VISIBILITY: ConnectionVisibility = "hidden"
 DISCOVERABLE_VISIBILITIES = frozenset({"visible_to_run", "open_to_connect"})
 ELIGIBLE_PARTICIPATION_STATUSES = frozenset({"checked_in", "completed"})
+# Only these two states can start a new request cycle, and only on later verified
+# shared play. "blocked" is permanently terminal in this phase.
+REOPENABLE_STATUSES = frozenset({"declined", "removed"})
 OPAQUE_ID_PATTERN = r"^[a-f0-9]{32}$"
 PAIR_KEY_PATTERN = r"^[a-f0-9]{64}$"
 SAFE_DISPLAY_NAME_FALLBACK = "SportBeacon athlete"
@@ -76,6 +79,12 @@ class AthleteConnection(BaseModel):
     removedAt: Optional[datetime] = None
     blockedAt: Optional[datetime] = None
     blockedBy: Optional[str] = None
+    # Request-cycle audit. A Phase 3B document written before reconnection existed
+    # has none of these, so it deserializes as a first cycle with no prior state.
+    requestCycle: int = Field(default=1, ge=1)
+    lastRequestedAt: Optional[datetime] = None
+    previousStatus: Optional[ConnectionStatus] = None
+    previousStatusAt: Optional[datetime] = None
     isTestData: bool = False
 
     @field_validator("members")
@@ -98,6 +107,8 @@ class AthleteConnection(BaseModel):
             raise ValueError("pairKey must be canonical for the member pair")
         if self.blockedBy is not None and self.blockedBy not in self.members:
             raise ValueError("blockedBy must be a member")
+        if self.previousStatus is not None and self.previousStatus not in REOPENABLE_STATUSES:
+            raise ValueError("only a declined or removed cycle can precede a new request")
         return self
 
     def other_member(self, uid: str) -> str:

--- a/backend/connection_service.py
+++ b/backend/connection_service.py
@@ -9,6 +9,7 @@ from .connection_models import (
     DEFAULT_CONNECTION_VISIBILITY,
     DISCOVERABLE_VISIBILITIES,
     ELIGIBLE_PARTICIPATION_STATUSES,
+    REOPENABLE_STATUSES,
     SAFE_DISPLAY_NAME_FALLBACK,
     AthleteConnection,
     ConnectionConsentView,
@@ -62,6 +63,36 @@ def utc_now() -> datetime:
 def participation_is_eligible(record: Optional[Participation]) -> bool:
     """Only a verified check-in or a completed run proves shared play."""
     return record is not None and record.status in ELIGIBLE_PARTICIPATION_STATUSES
+
+
+def as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def terminal_boundary(record: AthleteConnection) -> datetime:
+    """The instant the current declined/removed cycle ended.
+
+    Falls back to ``updatedAt`` so a document written before the marker existed
+    still gets a server timestamp to measure new shared play against, rather than
+    an absent boundary that anything could clear.
+    """
+    marker = record.declinedAt if record.status == "declined" else record.removedAt
+    return as_utc(marker or record.updatedAt)
+
+
+def check_in_is_newer_than(record: Participation, boundary: datetime) -> bool:
+    """Server-authoritative proof that this athlete played again after the boundary.
+
+    ``checkedInAt`` is stamped from the server clock inside the check-in
+    transaction and is never accepted from a request body, so a client cannot
+    move it. A ``completed`` record carrying no check-in evidence proves nothing
+    and does not qualify.
+    """
+    if record.checkedInAt is None:
+        return False
+    return as_utc(record.checkedInAt) > boundary
 
 
 class AthleteConnectionService:
@@ -141,8 +172,11 @@ class AthleteConnectionService:
                     displayName=self._safe_display_name(other.uid),
                     connectionState=state,
                     canRequest=(
-                        relationship is None
-                        and other.connectionVisibility == "open_to_connect"
+                        other.connectionVisibility == "open_to_connect"
+                        and (
+                            relationship is None
+                            or self._may_reopen(relationship, run_id, mine, other)
+                        )
                     ),
                     connectionId=relationship.connectionId if relationship else None,
                     runId=run_id,
@@ -172,23 +206,55 @@ class AthleteConnectionService:
         is_test_data = run.isTestData or place.isTestData
 
         def _mutate(current: Optional[AthleteConnection]) -> Optional[AthleteConnection]:
-            if current is not None:
-                # Duplicate, reversed, and concurrent requests all converge on the
-                # single canonical document, so no second relationship can appear.
+            if current is None:
+                return AthleteConnection(
+                    pairKey=pair_key,
+                    connectionId=self._new_id(),
+                    members=canonical_members(uid, target.uid),
+                    requesterUid=uid,
+                    recipientUid=target.uid,
+                    status="pending",
+                    qualifyingRunId=run.id,
+                    qualifyingPlaceId=place.id,
+                    createdAt=now,
+                    updatedAt=now,
+                    requestCycle=1,
+                    lastRequestedAt=now,
+                    isTestData=is_test_data,
+                )
+            if current.status not in REOPENABLE_STATUSES:
+                # Blocked stays blocked, and a live pending or accepted relationship
+                # absorbs duplicate, reversed, and concurrent requests. All of them
+                # converge on the single canonical document, so no second
+                # relationship and no second pending cycle can appear.
                 return None
-            return AthleteConnection(
-                pairKey=pair_key,
-                connectionId=self._new_id(),
-                members=canonical_members(uid, target.uid),
-                requesterUid=uid,
-                recipientUid=target.uid,
-                status="pending",
-                qualifyingRunId=run.id,
-                qualifyingPlaceId=place.id,
-                createdAt=now,
-                updatedAt=now,
-                isTestData=is_test_data,
+            if not self._may_reopen(current, run.id, mine, target):
+                # The previous cycle's run, an older run, or missing check-in
+                # evidence never reopens a relationship.
+                raise AthleteConnectionError(403, CANDIDATE_UNAVAILABLE)
+            reopened = current.model_copy(
+                update={
+                    "status": "pending",
+                    # Roles follow the athlete who asked this time, so a reversed
+                    # reconnection is a genuine new request, not a revived old one.
+                    "requesterUid": uid,
+                    "recipientUid": target.uid,
+                    "qualifyingRunId": run.id,
+                    "qualifyingPlaceId": place.id,
+                    "requestCycle": current.requestCycle + 1,
+                    "lastRequestedAt": now,
+                    "previousStatus": current.status,
+                    "previousStatusAt": terminal_boundary(current),
+                    # The new cycle carries no outcome yet.
+                    "acceptedAt": None,
+                    "declinedAt": None,
+                    "removedAt": None,
+                    "updatedAt": now,
+                    "isTestData": current.isTestData or is_test_data,
+                }
             )
+            # Rewriting the roles must never break the pair identity they belong to.
+            return AthleteConnection.model_validate(reopened.model_dump())
 
         stored = self._connections.apply_connection_transition(pair_key, _mutate)
         if stored is None:
@@ -387,6 +453,28 @@ class AthleteConnectionService:
                 return record
         logger.info("connection_candidate_unresolved", extra={"run_id": run_id})
         raise AthleteConnectionError(404, CANDIDATE_UNAVAILABLE)
+
+    def _may_reopen(
+        self,
+        record: AthleteConnection,
+        run_id: str,
+        mine: Participation,
+        theirs: Participation,
+    ) -> bool:
+        """New verified shared play: a later run both athletes provably played again.
+
+        Callers have already established mutual visibility, eligible participation,
+        that the target chose ``open_to_connect``, and that neither athlete blocked
+        the other. This adds the anti-harassment gate on top: a genuinely later run,
+        proven by server-stamped check-in evidence on both sides.
+        """
+        if record.status not in REOPENABLE_STATUSES:
+            return False
+        if run_id == record.qualifyingRunId:
+            # The run that produced the previous cycle can never reopen it.
+            return False
+        boundary = terminal_boundary(record)
+        return check_in_is_newer_than(mine, boundary) and check_in_is_newer_than(theirs, boundary)
 
     def _is_blocked_pair(self, uid_a: str, uid_b: str) -> bool:
         record = self._connections.get_connection(canonical_pair_key(uid_a, uid_b))

--- a/backend/sports_loop_fixtures.py
+++ b/backend/sports_loop_fixtures.py
@@ -7,6 +7,13 @@ from .sports_loop_repository import SportsLoopRepository
 
 PLACE_ID = "test-place-richmond-rec-gym"
 ACTIVE_RUN_ID = "test-run-basketball-active"
+# Two further check-in-open sessions at the same place. Reconnecting after a decline
+# or a removal requires a *later* run both athletes checked into, so a two-account
+# acceptance run needs more than one open session to exercise the lifecycle without
+# hand-editing Firestore. They are ordinary labeled TEST DATA runs: no athlete is
+# invented, nobody is auto-joined, and consent still starts hidden on each of them.
+SECOND_ACTIVE_RUN_ID = "test-run-basketball-active-second"
+THIRD_ACTIVE_RUN_ID = "test-run-basketball-active-third"
 UPCOMING_RUN_ID = "test-run-basketball-upcoming"
 COMPLETED_RUN_ID = "test-run-basketball-completed"
 CANCELLED_RUN_ID = "test-run-basketball-cancelled"
@@ -40,6 +47,34 @@ def build_test_runs(now: datetime, place_id: str = PLACE_ID) -> list[Run]:
             title="TEST DATA — Lunch pickup run",
             startsAt=stamp - timedelta(minutes=45),
             endsAt=stamp + timedelta(minutes=75),
+            status="scheduled",
+            createdBy=FIXTURE_CREATED_BY,
+            visibility="authenticated",
+            isTestData=True,
+            createdAt=stamp,
+            updatedAt=stamp,
+        ),
+        Run(
+            id=SECOND_ACTIVE_RUN_ID,
+            sport="basketball",
+            placeId=place_id,
+            title="TEST DATA — Second pickup run (later session)",
+            startsAt=stamp - timedelta(minutes=30),
+            endsAt=stamp + timedelta(minutes=90),
+            status="scheduled",
+            createdBy=FIXTURE_CREATED_BY,
+            visibility="authenticated",
+            isTestData=True,
+            createdAt=stamp,
+            updatedAt=stamp,
+        ),
+        Run(
+            id=THIRD_ACTIVE_RUN_ID,
+            sport="basketball",
+            placeId=place_id,
+            title="TEST DATA — Third pickup run (latest session)",
+            startsAt=stamp - timedelta(minutes=15),
+            endsAt=stamp + timedelta(minutes=105),
             status="scheduled",
             createdBy=FIXTURE_CREATED_BY,
             visibility="authenticated",

--- a/docs/phase-3b-athlete-connections.md
+++ b/docs/phase-3b-athlete-connections.md
@@ -1,8 +1,10 @@
 # Phase 3B — Private Athlete Connections from Shared Play
 
-Status: implemented on `feat/phase-3b-athlete-connections`. This document is the architecture record.
-`docs/phase-3b-athlete-connection.md` remains the earlier candidate design note; this file records what
-was actually built and where the two differ.
+Status: merged as PR #21, then corrected on `fix/phase-3b-connection-lifecycle` before live
+acceptance. This document is the architecture record. `docs/phase-3b-athlete-connection.md` remains
+the earlier candidate design note; this file records what was actually built and where the two
+differ. The one behavioural change since the merge is in
+[Reconnection after later verified shared play](#reconnection-after-later-verified-shared-play).
 
 ## Existing baseline
 
@@ -30,6 +32,8 @@ Two athletes who actually played the same run can stay in touch without exchangi
 4. A request is possible only when the target chose `open_to_connect` on that shared run.
 5. The recipient accepts or declines. Acceptance produces a connection both athletes see on return to Play.
 6. Either athlete can remove, block, or report at any time.
+7. If a request was declined or a connection was removed, the two can start over — but only after
+   they play another run together, and never after a block.
 
 Nothing is automatic. Choosing a visibility level never creates a connection, and there is no
 suggestion engine, public search, follower count, or contact-detail exchange.
@@ -95,11 +99,28 @@ Member UIDs are stored inside the document for authorization and for the
 
 ```
 (none) --request--> pending --accept--> accepted --remove--> removed
-                       |                    |
-                       +-----decline----> declined
-                       |                    |
-                       +------block-------> blocked <----block---- accepted
+                       |                    |                   |
+                       +-----decline----> declined              |
+                       |                    |                   |
+                       |                    +--- later verified shared play ---+
+                       |                    |                                  |
+                       |                    +----------> pending (new cycle) <-+
+                       |
+                       +------block-------> blocked  <----block---- any non-blocked state
 ```
+
+| From | To | Trigger | Who |
+| --- | --- | --- | --- |
+| *(none)* | `pending` | request on a run both athletes played | either athlete |
+| `pending` | `accepted` | accept | recipient only |
+| `pending` | `declined` | decline | recipient only |
+| `pending` | `blocked` | block | either member |
+| `accepted` | `removed` | remove | either member |
+| `accepted` | `blocked` | block | either member |
+| `declined` | `pending` | request on **later verified shared play** | either athlete |
+| `removed` | `pending` | request on **later verified shared play** | either athlete |
+| `declined` / `removed` | `blocked` | block | either member |
+| `blocked` | — | nothing. Permanently terminal in this phase, and there is no unblock endpoint | — |
 
 Server-enforced rules, all inside one transaction per transition:
 
@@ -118,11 +139,88 @@ Server-enforced rules, all inside one transaction per transition:
 | Blocking supersedes pending and accepted | Blocking is allowed from any live state and records `blockedBy` |
 | Blocked pairs stay invisible | Discovery skips blocked pairs, so neither athlete reappears on any run |
 | A blocked pair cannot be revived through another run | The pair key is run-independent, so a later shared run still resolves to the blocked document |
+| A declined or removed pair reopens only on later verified shared play | The request mutation re-checks the gate below inside the same transaction |
 | No unblock | Not implemented in this phase |
 
-`declined` and `removed` are terminal for this phase: they are not re-requestable. Re-request windows
-need rate limiting and abuse review that are out of scope here, and leaving the state terminal is the
-fail-closed choice.
+## Reconnection after later verified shared play
+
+The first cut of this phase made `declined` and `removed` permanently terminal. That contradicted the
+acceptance sequence the phase was supposed to prove — connect, remove, reconnect, block — so the
+sequence could never have been completed against the implemented state machine. Rewriting the
+checklist to hide the contradiction would have shipped a lifecycle nobody could exercise, so the
+lifecycle is what changed.
+
+The safety property that made terminal states attractive is preserved by a different gate: **an
+athlete cannot ask again just because they want to. They can ask again only because the two of them
+actually played together again.** Shared play is scarce, physical, and mutual, so it is a harder
+thing to manufacture than a cooling-off timer, and it needs no rate-limit infrastructure.
+
+A request against a `declined` or `removed` relationship reopens it only when **all** of the
+following hold. Any single failure returns the same uniform refusal as every other unreachable
+outcome:
+
+1. **A different run.** The `runId` is not the relationship's current `qualifyingRunId`. The run that
+   produced the previous cycle can never reopen it.
+2. **Both athletes hold eligible participation** — `checked_in` or `completed` — on that run. `going`
+   is intent, not proof of play, and is rejected here exactly as it is everywhere else in this phase.
+3. **Both participation records carry server check-in evidence newer than the ending.** Each side's
+   `checkedInAt` must be strictly later than the relationship's `declinedAt` or `removedAt`. A
+   `completed` record with no check-in stamp proves nothing about *when* the athletes played and does
+   not qualify.
+4. **Both athletes are mutually visible on that run.** The caller is not `hidden` and the target is
+   discoverable, the same mutual-visibility rule discovery already uses.
+5. **The target currently chose `open_to_connect`** on that run, re-read at request time rather than
+   trusted from a client snapshot.
+6. **Neither athlete blocked the other.** `blocked` is checked before anything else and is terminal.
+
+Why each part is load-bearing:
+
+- **`checkedInAt` is server-authoritative.** It is stamped from the server clock inside the check-in
+  transaction; `POST /api/runs/{runId}/check-in` accepts no body at all, so there is no field for a
+  client to send and nothing for a client to alter.
+- **Check-in is stamped once.** Re-posting a check-in on a run an athlete already checked into is
+  idempotent and does not refresh the stamp, so an athlete cannot replay an old run to manufacture
+  newer evidence.
+- **Strictly later, not "at least as late".** A check-in recorded in the same instant the connection
+  ended is not later play, so it does not qualify.
+- **An older run cannot be reused.** A run with a different id still fails on the timestamp rule when
+  the pair played it before the ending, which is the case rules 1 and 3 cover together.
+
+`blocked` remains permanently terminal, discovery still skips blocked pairs entirely, and a declined
+or removed relationship can still be blocked before it is ever reopened — which is the control an
+athlete uses when they want a decline to be final.
+
+### Request-cycle audit fields
+
+Reopening rewrites one document. It never creates a second relationship, and the client-facing
+`connectionId` is deliberately unchanged so an athlete's own opaque handle stays stable across
+cycles.
+
+| Field | Meaning |
+| --- | --- |
+| `requestCycle` | How many request cycles this pair has had. Starts at `1` and increments on each reopen. |
+| `lastRequestedAt` | When the current cycle's request was made. |
+| `previousStatus` | The state the current cycle was reopened from: `declined` or `removed`, never `blocked`. |
+| `previousStatusAt` | When that previous cycle ended — the boundary the new check-in evidence had to beat. |
+
+Reopening also sets `status` to `pending`, moves `qualifyingRunId`/`qualifyingPlaceId` to the new
+run's evidence, rewrites `requesterUid`/`recipientUid` so the roles describe **this** request (a
+reversed reconnection is a genuine new request, not a revived old one), and clears `acceptedAt`,
+`declinedAt`, and `removedAt` so the new cycle carries no stale outcome. `pairKey`, `members`,
+`connectionId`, and `createdAt` are untouched.
+
+Because the roles are the only identity-bearing fields a reopen rewrites, the reopened record is
+re-validated before it is persisted, so a rewrite can never leave the members and the pair key
+disagreeing.
+
+### Compatibility with stored Phase 3B documents
+
+All four fields are optional with defaults, so a document written before reconnection existed
+deserializes as an untouched first cycle: `requestCycle` is `1`, and the other three are absent. No
+migration job runs and no document is rewritten until the pair actually reopens. A stored `declined`
+or `removed` document that predates the `declinedAt`/`removedAt` markers falls back to `updatedAt`
+as the boundary, so an absent marker still yields a real server timestamp to measure new shared play
+against rather than an empty boundary that anything could clear.
 
 ### Error disclosure
 
@@ -243,6 +341,26 @@ UX and accessibility decisions:
   response degrades to an empty list instead of blanking the app.
 - Fixture co-players stay labeled `Test data — staging fixture athlete`. No athlete is invented and
   no fixture auto-accepts in the product experience.
+- The server decides whether a request is possible; the panel only puts that decision in plain
+  language. A declined or removed co-player is described as reconnectable **only** when the server
+  already set `canRequest`, at which point the action reads `Reconnect` and the card explains that
+  playing this run together after the last ending is what earned the new request. Until then the card
+  says the pair needs a later run they both check into — it never promises immediate reconnection.
+- Removal and blocking are stated as different things wherever either is offered: removal ends the
+  connection and needs a later shared run before anyone can ask again, blocking is permanent and
+  cannot be undone.
+
+## Acceptance fixtures
+
+Reconnection needs a *later* run both athletes checked into, and the labeled fixture set previously
+had exactly one run with an open check-in window, so the sequence could not be walked end to end
+without hand-editing Firestore. Two further labeled TEST DATA runs at the same test place —
+`test-run-basketball-active-second` and `test-run-basketball-active-third` — now open alongside
+`test-run-basketball-active`, staggered so they list in session order.
+
+They are ordinary fixture runs and change nothing else: no synthetic athlete account is created,
+nobody is auto-joined or auto-accepted, consent still starts `hidden` on every one of them, and they
+follow the existing rule that fixtures never load in production.
 
 ## Explicit non-goals
 
@@ -252,7 +370,8 @@ notifications of any kind, municipal connectors, tournaments, payments, scheduli
 Firebase database access, new Firebase services, new IAM roles or secrets, production Cloud Run
 changes, Vercel Production deployment, and service-account key rotation.
 
-Unblock is intentionally absent. So is re-requesting after a decline.
+Unblock is intentionally absent, and so is any broad rate-limit or cooling-off infrastructure:
+the later shared run *is* the anti-harassment gate for this phase.
 
 ## Test strategy
 
@@ -262,7 +381,16 @@ Unblock is intentionally absent. So is re-requesting after a decline.
   self-request rejection, target not open, duplicate and reversed idempotency, concurrent requests,
   recipient-only accept and decline, removal, blocking superseding pending and accepted state,
   blocked rediscovery prevention across a second run, report authorization and validation, payload
-  scanning for private material, and log hygiene.
+  scanning for private material, and log hygiene. The reconnection rows are covered in the same file:
+  a declined or removed pair refused on the same run, refused on a run they played *before* the
+  ending, refused when either side lacks a server check-in stamp, refused when the check-in is
+  simultaneous with the ending rather than later, refused when a replayed check-in fails to re-stamp,
+  refused while either athlete is only `going`, refused while the target is not `open_to_connect`,
+  allowed on genuinely later shared play from either direction, idempotent under duplicate and
+  concurrent reversed later-run requests, stable in pair document and opaque connection id across
+  cycles, correct in every audit field, never reopenable once blocked, blockable while still
+  declined, compatible with a stored document that has no audit fields, and free of private or
+  server-only material in both responses and logs.
 - `tests/test_production_api_safety.py` proves every connection path stays 404 in production, including
   when `ENABLE_AUTHENTICATED_PROFILE_ROUTES` is true.
 - `tests/test_runtime_fail_closed.py` proves an invalid or missing `APP_ENV` hides the connection paths
@@ -273,7 +401,38 @@ Unblock is intentionally absent. So is re-requesting after a decline.
 - `frontend/src/App.test.tsx` covers the locked-before-check-in state, hidden-by-default copy, consent
   change, safe-identity-only rendering, `visible_to_run` withholding the request action, sending exactly
   one request, safe server refusals, accept, decline, remove, block, the report receipt, and malformed
-  response tolerance — alongside the existing Phase 2B and 3A regressions.
+  response tolerance — alongside the existing Phase 2B and 3A regressions. It also covers the
+  reconnect action and its explanation appearing only when the server allows it, the same-run case
+  offering no action and stating the later-run requirement instead, and removal being described
+  differently from a permanent block.
+
+## Corrected two-account acceptance procedure
+
+The sequence below is the one this lifecycle actually supports. It needs two real accounts on the
+Preview URL and a staging backend running with `ENABLE_ATHLETE_CONNECTIONS=true`.
+
+1. Account A and Account B each join and check into **Run 1** (`TEST DATA — Lunch pickup run`).
+2. Both choose `open_to_connect` on Run 1. Confirm each sees only the other's display name — no
+   email, phone number, location, or home area.
+3. A sends a request to B. B sees it under Incoming requests and accepts.
+4. Both refresh, navigate away to Play, and return: the connection is still under Connected athletes.
+5. A removes the connection. It disappears for both, and the panel states that a new request needs a
+   later run they both check into.
+6. On Run 1, neither account can reconnect: the co-player card offers no Connect or Reconnect action
+   and explains the later-run requirement. A replayed request against Run 1 is refused.
+7. Both join and check into **Run 2** (`TEST DATA — Second pickup run (later session)`).
+8. Both choose `open_to_connect` on Run 2.
+9. The card now offers **Reconnect** and explains that playing this run together after the last
+   ending is what allows it. Either account may send it; B accepts.
+10. B blocks A.
+11. On Run 2 and on **Run 3** (`TEST DATA — Third pickup run (latest session)`), neither account can
+    rediscover or reconnect with the other, in either direction, no matter how many further runs they
+    both check into. There is no unblock control anywhere in the UI.
+12. Safety reporting still works from both a connection card and a co-player card, returns only
+    `Report received. Our safety team reviews reports privately.`, and exposes no way to read a report
+    back.
+13. Production stays health-only, IAM is unchanged, and a direct browser Firestore read of
+    `environments/staging/athleteConnections` still returns 401/403.
 
 ## Rollback
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1077,6 +1077,139 @@ describe("Phase 3B athlete connections", () => {
     expect(screen.queryByTestId("connection-conn-12")).not.toBeInTheDocument();
   });
 
+  it("offers a reconnect request only after the athletes played together again", async () => {
+    const runs = checkedInRuns();
+    const requested: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      workspaceFetch({
+        runs,
+        coPlayers: {
+          myVisibility: "open_to_connect",
+          discoverable: true,
+          items: [
+            sampleCoPlayer({
+              candidateId: "cand-removed-1",
+              displayName: "Blake",
+              connectionState: "removed",
+              canRequest: true,
+            }),
+          ],
+        },
+        onConnectionRequest: (candidateId) => {
+          requested.push(candidateId);
+          return jsonResponse({
+            connectionId: "conn-20",
+            displayName: "Blake",
+            status: "pending",
+            direction: "outgoing",
+            runId: runs[0].id,
+            placeId: "test-place-richmond-rec-gym",
+            isTestData: true,
+          });
+        },
+      }),
+    );
+    await signInToWorkspace();
+    await userEvent.click(screen.getAllByRole("button", { name: "View" })[0]);
+    const card = await screen.findByTestId("co-player-cand-removed-1");
+    expect(within(card).getByTestId("reconnect-note-cand-removed-1")).toHaveTextContent(
+      "You played this run together after your last connection ended, so you can send one new request.",
+    );
+    await userEvent.click(
+      within(card).getByRole("button", {
+        name: "Send a new connection request to Blake after playing together again",
+      }),
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("co-player-state")).toHaveTextContent(
+        "Connection request sent to Blake.",
+      );
+    });
+    expect(requested).toEqual(["cand-removed-1"]);
+  });
+
+  it("does not offer reconnection on the run the connection already ended on", async () => {
+    const runs = checkedInRuns();
+    vi.stubGlobal(
+      "fetch",
+      workspaceFetch({
+        runs,
+        coPlayers: {
+          myVisibility: "open_to_connect",
+          discoverable: true,
+          items: [
+            sampleCoPlayer({
+              candidateId: "cand-removed-2",
+              displayName: "Blake",
+              connectionState: "removed",
+              canRequest: false,
+            }),
+            sampleCoPlayer({
+              candidateId: "cand-declined-3",
+              displayName: "Casey",
+              connectionState: "declined",
+              canRequest: false,
+            }),
+          ],
+        },
+      }),
+    );
+    await signInToWorkspace();
+    await userEvent.click(screen.getAllByRole("button", { name: "View" })[0]);
+    const removed = await screen.findByTestId("co-player-cand-removed-2");
+    expect(removed).toHaveTextContent(
+      "Your connection with Blake ended. You can ask again only after you both check into a later run together.",
+    );
+    const declined = screen.getByTestId("co-player-cand-declined-3");
+    expect(declined).toHaveTextContent(
+      "Casey declined your last request. You can ask once more only after you both check into a later run together.",
+    );
+    expect(screen.queryByRole("button", { name: /connection request/i })).not.toBeInTheDocument();
+    expect(screen.queryByTestId("reconnect-note-cand-removed-2")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("reconnect-note-cand-declined-3")).not.toBeInTheDocument();
+  });
+
+  it("separates a reversible removal from a permanent block", async () => {
+    vi.stubGlobal(
+      "fetch",
+      workspaceFetch({
+        runs: sampleRuns(),
+        connections: {
+          incoming: [sampleConnection({ connectionId: "conn-21", displayName: "Casey" })],
+          outgoing: [],
+          accepted: [
+            sampleConnection({
+              connectionId: "conn-22",
+              displayName: "Blake",
+              status: "accepted",
+              direction: "mutual",
+            }),
+          ],
+        },
+      }),
+    );
+    await signInToWorkspace();
+    const acceptedGroup = await screen.findByTestId("connections-accepted");
+    expect(acceptedGroup).toHaveTextContent(
+      "Removing ends the connection for both athletes. Neither of you can send a new request until you both check into a later run together. Blocking is permanent and cannot be undone.",
+    );
+    const incomingGroup = screen.getByTestId("connections-incoming");
+    expect(incomingGroup).toHaveTextContent(
+      "Declining ends this request. That athlete can ask once more only after you both check into a later run together. Blocking is permanent and cannot be undone.",
+    );
+    expect(
+      within(acceptedGroup).getByRole("button", { name: "Remove your connection with Blake" }),
+    ).toBeInTheDocument();
+    expect(
+      within(acceptedGroup).getByRole("button", { name: "Block Blake" }),
+    ).toBeInTheDocument();
+    expect(document.body.textContent).not.toMatch(
+      /can (reconnect|connect again|send a new request) (right away|immediately|now)/i,
+    );
+    expect(document.body.textContent).not.toMatch(/unblock/i);
+  });
+
   it("confirms a safety report without echoing the stored report", async () => {
     const accepted = sampleConnection({
       connectionId: "conn-13",

--- a/frontend/src/connections/AthleteConnections.tsx
+++ b/frontend/src/connections/AthleteConnections.tsx
@@ -84,6 +84,12 @@ const VISIBILITY_CHOICES: Array<{
 const PRIVACY_NOTE =
   "SportBeacon never shares your email, phone number, exact location, or home area. Only athletes who checked into this same run can ever see you here.";
 
+const DECLINE_NOTE =
+  "Declining ends this request. That athlete can ask once more only after you both check into a later run together. Blocking is permanent and cannot be undone.";
+
+const REMOVE_NOTE =
+  "Removing ends the connection for both athletes. Neither of you can send a new request until you both check into a later run together. Blocking is permanent and cannot be undone.";
+
 /** Never trust the shape of a response body: a stale backend must not blank the app. */
 function asList<T>(value: unknown): T[] {
   return Array.isArray(value) ? (value as T[]) : [];
@@ -121,6 +127,33 @@ function stateLabel(state: CoPlayerConnectionState): string {
       return "Connection removed";
     default:
       return "Not connected";
+  }
+}
+
+const ENDED_STATES: CoPlayerConnectionState[] = ["declined", "removed"];
+
+/** A request here would reopen an earlier connection the two athletes already ended. */
+function isReconnect(item: CoPlayer): boolean {
+  return item.canRequest && ENDED_STATES.includes(item.connectionState);
+}
+
+/**
+ * Why this athlete cannot be asked right now.
+ *
+ * The server decides; this only puts the decision in plain language. A declined or
+ * removed athlete is never described as reconnectable until the server says so,
+ * because playing the same run again is what earns a new request.
+ */
+function unavailableReason(item: CoPlayer): string {
+  switch (item.connectionState) {
+    case "declined":
+      return `${item.displayName} declined your last request. You can ask once more only after you both check into a later run together.`;
+    case "removed":
+      return `Your connection with ${item.displayName} ended. You can ask again only after you both check into a later run together.`;
+    case "none":
+      return `${item.displayName} is visible but not open to requests.`;
+    default:
+      return stateLabel(item.connectionState);
   }
 }
 
@@ -239,21 +272,27 @@ export function RunConnectionPanel({
               {item.isTestData ? (
                 <p className="test-data-label">Test data — staging fixture athlete</p>
               ) : null}
+              {isReconnect(item) ? (
+                <p className="choice-description" data-testid={`reconnect-note-${item.candidateId}`}>
+                  You played this run together after your last connection ended, so you can send
+                  one new request. {item.displayName} still chooses whether to accept.
+                </p>
+              ) : null}
               <div className="text-actions">
                 {item.canRequest ? (
                   <button
                     type="button"
                     onClick={() => void sendRequest(item)}
-                    aria-label={`Send a connection request to ${item.displayName}`}
+                    aria-label={
+                      isReconnect(item)
+                        ? `Send a new connection request to ${item.displayName} after playing together again`
+                        : `Send a connection request to ${item.displayName}`
+                    }
                   >
-                    Connect
+                    {isReconnect(item) ? "Reconnect" : "Connect"}
                   </button>
                 ) : (
-                  <span className="choice-description">
-                    {item.connectionState === "none"
-                      ? `${item.displayName} is visible but not open to requests.`
-                      : stateLabel(item.connectionState)}
-                  </span>
+                  <span className="choice-description">{unavailableReason(item)}</span>
                 )}
               </div>
               <SafetyReportForm
@@ -338,6 +377,7 @@ export function ConnectionsPanel({
       <ConnectionGroup
         heading="Incoming requests"
         testId="connections-incoming"
+        note={DECLINE_NOTE}
         items={lists.incoming}
         emptyLabel="No incoming requests."
         renderActions={(item) => (
@@ -386,6 +426,7 @@ export function ConnectionsPanel({
       <ConnectionGroup
         heading="Connected athletes"
         testId="connections-accepted"
+        note={REMOVE_NOTE}
         items={lists.accepted}
         emptyLabel="No accepted connections yet."
         renderActions={(item) => (
@@ -415,6 +456,7 @@ export function ConnectionsPanel({
 function ConnectionGroup({
   heading,
   testId,
+  note,
   items,
   emptyLabel,
   renderActions,
@@ -422,6 +464,7 @@ function ConnectionGroup({
 }: {
   heading: string;
   testId: string;
+  note?: string;
   items: Connection[];
   emptyLabel: string;
   renderActions: (item: Connection) => JSX.Element;
@@ -430,6 +473,7 @@ function ConnectionGroup({
   return (
     <div className="connection-group" data-testid={testId}>
       <h3>{heading}</h3>
+      {note ? <p className="choice-description">{note}</p> : null}
       {items.length === 0 ? (
         <p className="form-message">{emptyLabel}</p>
       ) : (

--- a/tests/test_athlete_connections_api.py
+++ b/tests/test_athlete_connections_api.py
@@ -29,6 +29,8 @@ from backend.connection_service import AthleteConnectionService
 from backend.sports_loop_fixtures import (
     ACTIVE_RUN_ID,
     PLACE_ID,
+    SECOND_ACTIVE_RUN_ID,
+    THIRD_ACTIVE_RUN_ID,
     UPCOMING_RUN_ID,
     ensure_sports_loop_fixtures,
 )
@@ -77,6 +79,26 @@ class FakeVerifier:
         return uid
 
 
+class MovingClock:
+    """Server clock the tests advance explicitly.
+
+    Reconnecting after a decline or a removal is gated on check-in evidence
+    recorded *after* that ending, so a frozen clock cannot express the sequence
+    at all. Advancing it also lets a test prove that a same-instant check-in is
+    not "later".
+    """
+
+    def __init__(self, start: datetime) -> None:
+        self.now = start
+
+    def __call__(self) -> datetime:
+        return self.now
+
+    def advance(self, **delta: int) -> datetime:
+        self.now = self.now + timedelta(**delta)
+        return self.now
+
+
 def _auth(token: str = "header.user-a.sig") -> Dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
@@ -97,7 +119,7 @@ def _app_client(monkeypatch, extra=None, now=NOW):
     app.state.athlete_repository = athletes
     app.state.sports_loop_repository = sports
     app.state.connection_repository = connections
-    app.state.sports_loop_clock = lambda: now
+    app.state.sports_loop_clock = MovingClock(now)
     ensure_sports_loop_fixtures(sports, now)
     sports.upsert_run(
         Run(
@@ -143,6 +165,10 @@ def _gate_client(monkeypatch, env: Dict[str, Optional[str]]) -> TestClient:
     app.state.sports_loop_repository = InMemorySportsLoopRepository()
     app.state.connection_repository = InMemoryConnectionRepository()
     return TestClient(app)
+
+
+def _clock(client: TestClient) -> MovingClock:
+    return client.app.state.sports_loop_clock
 
 
 def _check_in(client: TestClient, token: str, run_id: str = ACTIVE_RUN_ID) -> None:
@@ -698,7 +724,7 @@ def test_both_athletes_see_the_accepted_connection(monkeypatch):
     assert listing["canRequest"] is False
 
 
-def test_only_the_recipient_can_decline_and_decline_is_terminal(monkeypatch):
+def test_only_the_recipient_can_decline_and_the_same_run_cannot_retry(monkeypatch):
     client, _, _, _ = _app_client(monkeypatch)
     candidates = _open_pair(client)
     connection_id = _request(client, "header.user-a.sig", candidates["b_candidate"]).json()[
@@ -859,6 +885,543 @@ def test_blocking_twice_is_safe_and_no_unblock_route_exists(monkeypatch):
             f"/api/me/connections/{connection_id}/{path}", headers=_auth("header.user-b.sig")
         )
         assert response.status_code == 404
+
+
+# ------------------------------------------------ reconnection after later play
+
+
+def _connect_and_accept(client: TestClient, run_id: str = ACTIVE_RUN_ID) -> str:
+    """The accepted state the two-account checklist reaches before a removal."""
+    candidates = _open_pair(client, run_id)
+    connection_id = _request(
+        client, "header.user-a.sig", candidates["b_candidate"], run_id
+    ).json()["connectionId"]
+    accepted = client.post(
+        f"/api/me/connections/{connection_id}/accept", headers=_auth("header.user-b.sig")
+    )
+    assert accepted.status_code == 200, accepted.text
+    return connection_id
+
+
+def _seed_participation_without_check_in(
+    sports: InMemorySportsLoopRepository, run_id: str, uid: str
+) -> None:
+    """A completed record carrying no server check-in stamp.
+
+    Eligible to be seen, but no proof of *when* the athlete played, so it can
+    never satisfy the later-shared-play gate.
+    """
+    run = sports.get_run(run_id)
+    place = sports.get_place(run.placeId)
+    sports.commit_join(
+        Participation(
+            uid=uid,
+            runId=run_id,
+            status="completed",
+            joinedAt=run.startsAt,
+            checkedInAt=None,
+            runTitle=run.title,
+            placeId=place.id,
+            placeName=place.name,
+            sport=run.sport,
+            startsAt=run.startsAt,
+            isTestData=True,
+        )
+    )
+
+
+def test_removed_connection_cannot_reopen_on_the_same_run(monkeypatch):
+    client, sports, connections, _ = _app_client(monkeypatch)
+    connection_id = _connect_and_accept(client)
+    _clock(client).advance(minutes=1)
+    removed = client.post(
+        f"/api/me/connections/{connection_id}/remove", headers=_auth("header.user-a.sig")
+    )
+    assert removed.json()["status"] == "removed"
+    entry = _co_players(client, "header.user-a.sig").json()["items"][0]
+    assert entry["connectionState"] == "removed"
+    assert entry["canRequest"] is False, "the run they already used cannot reopen it"
+    retry = _request(client, "header.user-a.sig", _candidate_id(sports, ACTIVE_RUN_ID, "user-b"))
+    assert retry.status_code == 403
+    assert retry.json()["detail"] == "That athlete is not available to connect from this run"
+    record = connections.get_connection(canonical_pair_key("user-a", "user-b"))
+    assert record.status == "removed"
+    assert record.requestCycle == 1
+
+
+def test_declined_request_cannot_reopen_on_the_same_run(monkeypatch):
+    client, sports, connections, _ = _app_client(monkeypatch)
+    candidates = _open_pair(client)
+    connection_id = _request(client, "header.user-a.sig", candidates["b_candidate"]).json()[
+        "connectionId"
+    ]
+    _clock(client).advance(minutes=1)
+    client.post(f"/api/me/connections/{connection_id}/decline", headers=_auth("header.user-b.sig"))
+    assert _co_players(client, "header.user-a.sig").json()["items"][0]["canRequest"] is False
+    retry = _request(client, "header.user-a.sig", _candidate_id(sports, ACTIVE_RUN_ID, "user-b"))
+    assert retry.status_code == 403
+    assert connections.get_connection(canonical_pair_key("user-a", "user-b")).requestCycle == 1
+
+
+def test_a_run_played_before_the_ending_cannot_reopen_a_relationship(monkeypatch):
+    """A different run is not enough: it has to be a run they played *afterwards*."""
+    client, sports, connections, _ = _app_client(monkeypatch)
+    _open_both_on_run(client, SECOND_RUN_ID)
+    connection_id = _connect_and_accept(client)
+    _clock(client).advance(minutes=5)
+    client.post(f"/api/me/connections/{connection_id}/remove", headers=_auth("header.user-a.sig"))
+    older = _co_players(client, "header.user-a.sig", SECOND_RUN_ID).json()["items"][0]
+    assert older["canRequest"] is False
+    retry = _request(
+        client,
+        "header.user-a.sig",
+        _candidate_id(sports, SECOND_RUN_ID, "user-b"),
+        SECOND_RUN_ID,
+    )
+    assert retry.status_code == 403
+    assert connections.get_connection(canonical_pair_key("user-a", "user-b")).status == "removed"
+
+
+def test_removed_connection_reopens_after_a_later_verified_shared_run(monkeypatch):
+    client, sports, connections, _ = _app_client(monkeypatch)
+    connection_id = _connect_and_accept(client)
+    pair_key = canonical_pair_key("user-a", "user-b")
+    original = connections.get_connection(pair_key)
+    _clock(client).advance(minutes=1)
+    client.post(f"/api/me/connections/{connection_id}/remove", headers=_auth("header.user-a.sig"))
+    removed_at = connections.get_connection(pair_key).removedAt
+
+    _clock(client).advance(minutes=10)
+    _open_both_on_run(client, SECOND_ACTIVE_RUN_ID)
+    listing = _co_players(client, "header.user-a.sig", SECOND_ACTIVE_RUN_ID).json()["items"][0]
+    assert listing["connectionState"] == "removed"
+    assert listing["canRequest"] is True, "playing together again earns one new request"
+
+    reopened = _request(
+        client,
+        "header.user-a.sig",
+        _candidate_id(sports, SECOND_ACTIVE_RUN_ID, "user-b"),
+        SECOND_ACTIVE_RUN_ID,
+    )
+    assert reopened.status_code == 200, reopened.text
+    body = reopened.json()
+    assert body["status"] == "pending"
+    assert body["direction"] == "outgoing"
+    assert body["connectionId"] == connection_id, "the opaque client id survives a new cycle"
+    assert body["runId"] == SECOND_ACTIVE_RUN_ID, "the new qualifying run is recorded"
+    assert body["acceptedAt"] is None
+    _assert_no_private_material(body)
+
+    record = connections.get_connection(pair_key)
+    assert record.status == "pending"
+    assert record.requestCycle == 2
+    assert record.lastRequestedAt == _clock(client).now
+    assert record.previousStatus == "removed"
+    assert record.previousStatusAt == removed_at
+    assert record.removedAt is None and record.acceptedAt is None
+    assert record.qualifyingRunId == SECOND_ACTIVE_RUN_ID
+    assert record.qualifyingPlaceId == PLACE_ID
+    assert record.pairKey == pair_key, "the pair document is reused, never recreated"
+    assert record.connectionId == original.connectionId
+    assert record.createdAt == original.createdAt
+    assert len(connections.list_connections_for_member("user-a")) == 1
+
+    accepted = client.post(
+        f"/api/me/connections/{connection_id}/accept", headers=_auth("header.user-b.sig")
+    )
+    assert accepted.status_code == 200, accepted.text
+    assert accepted.json()["status"] == "accepted"
+
+
+def test_declined_request_reopens_with_the_reversed_requester(monkeypatch):
+    """The athlete who declined may be the one who asks on the next cycle."""
+    client, sports, connections, _ = _app_client(monkeypatch)
+    candidates = _open_pair(client)
+    connection_id = _request(client, "header.user-a.sig", candidates["b_candidate"]).json()[
+        "connectionId"
+    ]
+    _clock(client).advance(minutes=1)
+    client.post(f"/api/me/connections/{connection_id}/decline", headers=_auth("header.user-b.sig"))
+
+    _clock(client).advance(minutes=10)
+    _open_both_on_run(client, SECOND_ACTIVE_RUN_ID)
+    reopened = _request(
+        client,
+        "header.user-b.sig",
+        _candidate_id(sports, SECOND_ACTIVE_RUN_ID, "user-a"),
+        SECOND_ACTIVE_RUN_ID,
+    )
+    assert reopened.status_code == 200, reopened.text
+    assert reopened.json()["direction"] == "outgoing"
+    assert reopened.json()["displayName"] == "Ada"
+    assert reopened.json()["connectionId"] == connection_id
+
+    record = connections.get_connection(canonical_pair_key("user-a", "user-b"))
+    assert record.requesterUid == "user-b"
+    assert record.recipientUid == "user-a"
+    assert record.previousStatus == "declined"
+    assert record.requestCycle == 2
+    assert set(record.members) == {"user-a", "user-b"}
+
+    lists_a = client.get("/api/me/connections", headers=_auth("header.user-a.sig")).json()
+    assert len(lists_a["incoming"]) == 1 and lists_a["outgoing"] == []
+    assert (
+        client.post(
+            f"/api/me/connections/{connection_id}/accept", headers=_auth("header.user-b.sig")
+        ).status_code
+        == 403
+    ), "the athlete who asked this time cannot answer their own request"
+    assert (
+        client.post(
+            f"/api/me/connections/{connection_id}/accept", headers=_auth("header.user-a.sig")
+        ).status_code
+        == 200
+    )
+
+
+def test_reopening_needs_a_server_check_in_stamp_on_both_sides(monkeypatch):
+    client, sports, connections, _ = _app_client(monkeypatch)
+    connection_id = _connect_and_accept(client)
+    _clock(client).advance(minutes=1)
+    client.post(f"/api/me/connections/{connection_id}/remove", headers=_auth("header.user-a.sig"))
+    _clock(client).advance(minutes=10)
+
+    for uid in ("user-a", "user-b"):
+        _seed_participation_without_check_in(sports, THIRD_ACTIVE_RUN_ID, uid)
+    for token in ("header.user-a.sig", "header.user-b.sig"):
+        assert (
+            _set_visibility(client, token, "open_to_connect", THIRD_ACTIVE_RUN_ID).status_code == 200
+        )
+    assert _co_players(client, "header.user-a.sig", THIRD_ACTIVE_RUN_ID).json()["items"][0][
+        "canRequest"
+    ] is False
+    neither = _request(
+        client,
+        "header.user-a.sig",
+        _candidate_id(sports, THIRD_ACTIVE_RUN_ID, "user-b"),
+        THIRD_ACTIVE_RUN_ID,
+    )
+    assert neither.status_code == 403
+
+    # One real later check-in is still not enough: both athletes must prove it.
+    _seed_participation_without_check_in(sports, SECOND_ACTIVE_RUN_ID, "user-b")
+    _check_in(client, "header.user-a.sig", SECOND_ACTIVE_RUN_ID)
+    for token in ("header.user-a.sig", "header.user-b.sig"):
+        assert (
+            _set_visibility(client, token, "open_to_connect", SECOND_ACTIVE_RUN_ID).status_code
+            == 200
+        )
+    one_sided = _request(
+        client,
+        "header.user-a.sig",
+        _candidate_id(sports, SECOND_ACTIVE_RUN_ID, "user-b"),
+        SECOND_ACTIVE_RUN_ID,
+    )
+    assert one_sided.status_code == 403
+    assert connections.get_connection(canonical_pair_key("user-a", "user-b")).status == "removed"
+
+
+def test_a_check_in_recorded_before_the_removal_never_becomes_later(monkeypatch):
+    """Check-in is stamped once, so replaying it cannot manufacture new evidence."""
+    client, sports, connections, _ = _app_client(monkeypatch)
+    connection_id = _connect_and_accept(client)
+    _clock(client).advance(minutes=1)
+    _open_both_on_run(client, SECOND_ACTIVE_RUN_ID)
+    stamped_at = sports.get_participation(SECOND_ACTIVE_RUN_ID, "user-a").checkedInAt
+    # The connection ends in the same instant the pair checked into the later run.
+    client.post(f"/api/me/connections/{connection_id}/remove", headers=_auth("header.user-a.sig"))
+    same_instant = _request(
+        client,
+        "header.user-a.sig",
+        _candidate_id(sports, SECOND_ACTIVE_RUN_ID, "user-b"),
+        SECOND_ACTIVE_RUN_ID,
+    )
+    assert same_instant.status_code == 403, "evidence has to be newer, not simultaneous"
+
+    _clock(client).advance(minutes=5)
+    _check_in(client, "header.user-a.sig", SECOND_ACTIVE_RUN_ID)
+    _check_in(client, "header.user-b.sig", SECOND_ACTIVE_RUN_ID)
+    assert sports.get_participation(SECOND_ACTIVE_RUN_ID, "user-a").checkedInAt == stamped_at
+    assert (
+        _request(
+            client,
+            "header.user-a.sig",
+            _candidate_id(sports, SECOND_ACTIVE_RUN_ID, "user-b"),
+            SECOND_ACTIVE_RUN_ID,
+        ).status_code
+        == 403
+    )
+
+    _open_both_on_run(client, THIRD_ACTIVE_RUN_ID)
+    genuinely_later = _request(
+        client,
+        "header.user-a.sig",
+        _candidate_id(sports, THIRD_ACTIVE_RUN_ID, "user-b"),
+        THIRD_ACTIVE_RUN_ID,
+    )
+    assert genuinely_later.status_code == 200, genuinely_later.text
+    assert connections.get_connection(canonical_pair_key("user-a", "user-b")).requestCycle == 2
+
+
+def test_going_on_a_later_run_never_reopens_a_removed_connection(monkeypatch):
+    client, sports, connections, _ = _app_client(monkeypatch)
+    connection_id = _connect_and_accept(client)
+    _clock(client).advance(minutes=1)
+    client.post(f"/api/me/connections/{connection_id}/remove", headers=_auth("header.user-a.sig"))
+    _clock(client).advance(minutes=10)
+    _join(client, "header.user-a.sig", THIRD_ACTIVE_RUN_ID)
+    _join(client, "header.user-b.sig", THIRD_ACTIVE_RUN_ID)
+    assert (
+        _set_visibility(
+            client, "header.user-a.sig", "open_to_connect", THIRD_ACTIVE_RUN_ID
+        ).status_code
+        == 403
+    )
+    # Force consent onto both going records to prove status, not data shape, gates it.
+    for uid in ("user-a", "user-b"):
+        record = sports.get_participation(THIRD_ACTIVE_RUN_ID, uid)
+        sports._participants[(THIRD_ACTIVE_RUN_ID, uid)] = record.model_copy(
+            update={"connectionVisibility": "open_to_connect", "candidateId": new_opaque_id()}
+        )
+    forced = _request(
+        client,
+        "header.user-a.sig",
+        _candidate_id(sports, THIRD_ACTIVE_RUN_ID, "user-b"),
+        THIRD_ACTIVE_RUN_ID,
+    )
+    assert forced.status_code == 403
+    assert connections.get_connection(canonical_pair_key("user-a", "user-b")).status == "removed"
+
+
+def test_reopening_still_requires_the_target_to_be_open_to_connect(monkeypatch):
+    client, sports, connections, _ = _app_client(monkeypatch)
+    connection_id = _connect_and_accept(client)
+    _clock(client).advance(minutes=1)
+    client.post(f"/api/me/connections/{connection_id}/remove", headers=_auth("header.user-a.sig"))
+    _clock(client).advance(minutes=10)
+    _check_in(client, "header.user-a.sig", SECOND_ACTIVE_RUN_ID)
+    _check_in(client, "header.user-b.sig", SECOND_ACTIVE_RUN_ID)
+    assert (
+        _set_visibility(
+            client, "header.user-a.sig", "open_to_connect", SECOND_ACTIVE_RUN_ID
+        ).status_code
+        == 200
+    )
+    assert (
+        _set_visibility(
+            client, "header.user-b.sig", "visible_to_run", SECOND_ACTIVE_RUN_ID
+        ).status_code
+        == 200
+    )
+    listed = _co_players(client, "header.user-a.sig", SECOND_ACTIVE_RUN_ID).json()["items"][0]
+    assert listed["canRequest"] is False
+    refused = _request(
+        client,
+        "header.user-a.sig",
+        _candidate_id(sports, SECOND_ACTIVE_RUN_ID, "user-b"),
+        SECOND_ACTIVE_RUN_ID,
+    )
+    assert refused.status_code == 403
+    assert connections.get_connection(canonical_pair_key("user-a", "user-b")).status == "removed"
+
+    assert (
+        _set_visibility(
+            client, "header.user-b.sig", "open_to_connect", SECOND_ACTIVE_RUN_ID
+        ).status_code
+        == 200
+    )
+    allowed = _request(
+        client,
+        "header.user-a.sig",
+        _candidate_id(sports, SECOND_ACTIVE_RUN_ID, "user-b"),
+        SECOND_ACTIVE_RUN_ID,
+    )
+    assert allowed.status_code == 200, allowed.text
+
+
+def test_duplicate_and_concurrent_later_run_requests_stay_idempotent(monkeypatch):
+    client, sports, connections, athletes = _app_client(monkeypatch)
+    connection_id = _connect_and_accept(client)
+    _clock(client).advance(minutes=1)
+    client.post(f"/api/me/connections/{connection_id}/remove", headers=_auth("header.user-a.sig"))
+    _clock(client).advance(minutes=10)
+    _open_both_on_run(client, SECOND_ACTIVE_RUN_ID)
+
+    def _send(uid: str, candidate_id: str):
+        service = AthleteConnectionService(
+            sports, connections, athletes, clock=_clock(client)
+        )
+        return service.request_connection(uid, SECOND_ACTIVE_RUN_ID, candidate_id)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [
+            pool.submit(_send, "user-a", _candidate_id(sports, SECOND_ACTIVE_RUN_ID, "user-b")),
+            pool.submit(_send, "user-b", _candidate_id(sports, SECOND_ACTIVE_RUN_ID, "user-a")),
+        ]
+        views = [future.result() for future in futures]
+    assert views[0].connectionId == views[1].connectionId == connection_id
+    record = connections.get_connection(canonical_pair_key("user-a", "user-b"))
+    assert record.status == "pending"
+    assert record.requestCycle == 2, "two reversed requests are one new cycle, not two"
+    assert len(connections.list_connections_for_member("user-a")) == 1
+    assert len(connections.list_connections_for_member("user-b")) == 1
+
+    repeat = _request(
+        client,
+        "header.user-a.sig",
+        _candidate_id(sports, SECOND_ACTIVE_RUN_ID, "user-b"),
+        SECOND_ACTIVE_RUN_ID,
+    )
+    assert repeat.status_code == 200
+    assert repeat.json()["connectionId"] == connection_id
+    assert connections.get_connection(canonical_pair_key("user-a", "user-b")).requestCycle == 2
+
+
+def test_blocked_relationship_cannot_reopen_on_any_later_run(monkeypatch):
+    client, sports, connections, _ = _app_client(monkeypatch)
+    connection_id = _connect_and_accept(client)
+    _clock(client).advance(minutes=1)
+    blocked = client.post(
+        f"/api/me/connections/{connection_id}/block", headers=_auth("header.user-b.sig")
+    )
+    assert blocked.json()["status"] == "blocked"
+    for run_id in (SECOND_ACTIVE_RUN_ID, THIRD_ACTIVE_RUN_ID):
+        _clock(client).advance(minutes=10)
+        _open_both_on_run(client, run_id)
+        assert _co_players(client, "header.user-a.sig", run_id).json()["items"] == []
+        assert _co_players(client, "header.user-b.sig", run_id).json()["items"] == []
+        for token, other in (("header.user-a.sig", "user-b"), ("header.user-b.sig", "user-a")):
+            retry = _request(client, token, _candidate_id(sports, run_id, other), run_id)
+            assert retry.status_code == 403
+            assert (
+                retry.json()["detail"] == "That athlete is not available to connect from this run"
+            )
+    record = connections.get_connection(canonical_pair_key("user-a", "user-b"))
+    assert record.status == "blocked"
+    assert record.requestCycle == 1
+    assert record.previousStatus is None
+
+
+def test_a_declined_relationship_can_still_be_blocked_before_it_reopens(monkeypatch):
+    client, sports, connections, _ = _app_client(monkeypatch)
+    candidates = _open_pair(client)
+    connection_id = _request(client, "header.user-a.sig", candidates["b_candidate"]).json()[
+        "connectionId"
+    ]
+    _clock(client).advance(minutes=1)
+    client.post(f"/api/me/connections/{connection_id}/decline", headers=_auth("header.user-b.sig"))
+    blocked = client.post(
+        f"/api/me/connections/{connection_id}/block", headers=_auth("header.user-b.sig")
+    )
+    assert blocked.status_code == 200
+    assert blocked.json()["status"] == "blocked"
+    _clock(client).advance(minutes=10)
+    _open_both_on_run(client, SECOND_ACTIVE_RUN_ID)
+    retry = _request(
+        client,
+        "header.user-a.sig",
+        _candidate_id(sports, SECOND_ACTIVE_RUN_ID, "user-b"),
+        SECOND_ACTIVE_RUN_ID,
+    )
+    assert retry.status_code == 403
+    assert connections.get_connection(canonical_pair_key("user-a", "user-b")).status == "blocked"
+
+
+def test_documents_written_before_reconnection_existed_stay_compatible(monkeypatch):
+    """A Phase 3B document has no cycle fields, so it loads as an untouched first cycle."""
+    legacy = AthleteConnection.model_validate(
+        {
+            "pairKey": canonical_pair_key("user-a", "user-b"),
+            "connectionId": new_opaque_id(),
+            "members": sorted(["user-a", "user-b"]),
+            "requesterUid": "user-a",
+            "recipientUid": "user-b",
+            "status": "removed",
+            "qualifyingRunId": ACTIVE_RUN_ID,
+            "qualifyingPlaceId": PLACE_ID,
+            "createdAt": NOW,
+            "updatedAt": NOW,
+            "acceptedAt": NOW,
+            "isTestData": True,
+        }
+    )
+    assert legacy.requestCycle == 1
+    assert legacy.lastRequestedAt is None
+    assert legacy.previousStatus is None
+    assert legacy.previousStatusAt is None
+    assert legacy.removedAt is None, "the old document never recorded one"
+
+    client, sports, connections, _ = _app_client(monkeypatch)
+    connections.apply_connection_transition(legacy.pairKey, lambda _current: legacy)
+    _clock(client).advance(minutes=10)
+    _open_both_on_run(client, SECOND_ACTIVE_RUN_ID)
+    reopened = _request(
+        client,
+        "header.user-a.sig",
+        _candidate_id(sports, SECOND_ACTIVE_RUN_ID, "user-b"),
+        SECOND_ACTIVE_RUN_ID,
+    )
+    assert reopened.status_code == 200, reopened.text
+    assert reopened.json()["connectionId"] == legacy.connectionId
+    record = connections.get_connection(legacy.pairKey)
+    assert record.requestCycle == 2
+    assert record.previousStatus == "removed"
+    # With no removedAt to measure against, updatedAt is the boundary that stood.
+    assert record.previousStatusAt == legacy.updatedAt
+    assert len(connections.list_connections_for_member("user-a")) == 1
+
+
+def test_a_blocked_cycle_can_never_be_recorded_as_a_previous_state():
+    with pytest.raises(ValueError):
+        AthleteConnection(
+            pairKey=canonical_pair_key("user-a", "user-b"),
+            connectionId=new_opaque_id(),
+            members=sorted(["user-a", "user-b"]),
+            requesterUid="user-a",
+            recipientUid="user-b",
+            status="pending",
+            qualifyingRunId=ACTIVE_RUN_ID,
+            qualifyingPlaceId=PLACE_ID,
+            createdAt=NOW,
+            updatedAt=NOW,
+            requestCycle=2,
+            previousStatus="blocked",
+        )
+
+
+def test_a_reopened_cycle_leaks_no_private_material_or_audit_fields(monkeypatch, caplog):
+    client, sports, connections, _ = _app_client(monkeypatch)
+    connection_id = _connect_and_accept(client)
+    with caplog.at_level(logging.DEBUG):
+        _clock(client).advance(minutes=1)
+        client.post(
+            f"/api/me/connections/{connection_id}/remove", headers=_auth("header.user-a.sig")
+        )
+        _clock(client).advance(minutes=10)
+        _open_both_on_run(client, SECOND_ACTIVE_RUN_ID)
+        listing = _co_players(client, "header.user-a.sig", SECOND_ACTIVE_RUN_ID).json()
+        reopened = _request(
+            client,
+            "header.user-a.sig",
+            _candidate_id(sports, SECOND_ACTIVE_RUN_ID, "user-b"),
+            SECOND_ACTIVE_RUN_ID,
+        ).json()
+        lists = client.get("/api/me/connections", headers=_auth("header.user-b.sig")).json()
+    for payload in (listing, reopened, lists):
+        _assert_no_private_material(payload)
+        blob = json.dumps(payload)
+        for audit_field in ("requestCycle", "lastRequestedAt", "previousStatus", "previousStatusAt"):
+            assert audit_field not in blob, f"{audit_field} is server-only"
+    record = connections.get_connection(canonical_pair_key("user-a", "user-b"))
+    assert record.requestCycle == 2
+    blob = " ".join(
+        entry.getMessage() + " " + " ".join(str(value) for value in entry.__dict__.values())
+        for entry in caplog.records
+    )
+    for forbidden in list(TOKENS.values()) + list(TOKENS) + list(EMAILS.values()):
+        assert forbidden not in blob
+    for name in DISPLAY_NAMES.values():
+        assert name not in blob
 
 
 # ------------------------------------------------------------------ safety path

--- a/tests/test_firestore_emulator.py
+++ b/tests/test_firestore_emulator.py
@@ -402,3 +402,85 @@ def test_connection_consent_persists_on_both_participation_documents(monkeypatch
         is None
     )
 
+
+def test_a_reopened_cycle_reuses_the_same_stored_relationship(monkeypatch):
+    """A second request cycle rewrites one document; it never adds a second one."""
+    monkeypatch.setenv("APP_ENV", "test")
+    from datetime import timedelta
+
+    from google.cloud import firestore
+
+    from backend.connection_models import (
+        AthleteConnection,
+        canonical_members,
+        canonical_pair_key,
+        new_opaque_id,
+    )
+    from backend.connection_repository import FirestoreConnectionRepository
+    from backend.sports_loop_fixtures import ACTIVE_RUN_ID, PLACE_ID, SECOND_ACTIVE_RUN_ID
+
+    client = firestore.Client(project="sportbeacon-ai")
+    repo = FirestoreConnectionRepository(client=client, app_env="test")
+    now = datetime(2026, 8, 15, 18, 0, tzinfo=timezone.utc)
+    pair_key = canonical_pair_key("cycle-a", "cycle-b")
+    collection = (
+        client.collection("environments").document("test").collection("athleteConnections")
+    )
+    collection.document(pair_key).delete()
+
+    # A document shaped the way Phase 3B wrote it, with no request-cycle audit fields.
+    legacy = {
+        "pairKey": pair_key,
+        "connectionId": new_opaque_id(),
+        "members": canonical_members("cycle-a", "cycle-b"),
+        "requesterUid": "cycle-a",
+        "recipientUid": "cycle-b",
+        "status": "removed",
+        "qualifyingRunId": ACTIVE_RUN_ID,
+        "qualifyingPlaceId": PLACE_ID,
+        "createdAt": now,
+        "updatedAt": now,
+        "acceptedAt": now,
+        "removedAt": now,
+        "isTestData": True,
+    }
+    collection.document(pair_key).set(legacy)
+    loaded = repo.get_connection(pair_key)
+    assert loaded is not None
+    assert loaded.requestCycle == 1
+    assert loaded.lastRequestedAt is None
+    assert loaded.previousStatus is None
+
+    later = now + timedelta(hours=2)
+
+    def _reopen(current):
+        assert current is not None and current.status == "removed"
+        return current.model_copy(
+            update={
+                "status": "pending",
+                "requesterUid": "cycle-b",
+                "recipientUid": "cycle-a",
+                "qualifyingRunId": SECOND_ACTIVE_RUN_ID,
+                "requestCycle": current.requestCycle + 1,
+                "lastRequestedAt": later,
+                "previousStatus": "removed",
+                "previousStatusAt": current.removedAt,
+                "acceptedAt": None,
+                "removedAt": None,
+                "updatedAt": later,
+            }
+        )
+
+    reopened = repo.apply_connection_transition(pair_key, _reopen)
+    assert reopened.requestCycle == 2
+    assert reopened.connectionId == legacy["connectionId"]
+    stored = collection.document(pair_key).get().to_dict()
+    assert stored["requestCycle"] == 2
+    assert stored["previousStatus"] == "removed"
+    assert stored["removedAt"] is None
+    assert stored["qualifyingRunId"] == SECOND_ACTIVE_RUN_ID
+    assert AthleteConnection.model_validate(stored).status == "pending"
+    for uid in ("cycle-a", "cycle-b"):
+        assert [item.pairKey for item in repo.list_connections_for_member(uid)] == [pair_key]
+    collection.document(pair_key).delete()
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why this PR exists

[PR #21](https://github.com/TronDurell/sportbeacon-ai/pull/21) merged to `main` as `a209499` **before its two-account acceptance gate was ever executed**. Its own remaining-risks section says so: *"The two-account acceptance gate has not been executed. Every claim above is backed by automated tests, not by a live two-browser session."*

Running that gate would have failed immediately, because PR #21 contains a contradiction between its state machine and its acceptance checklist:

- **Its lifecycle decision** (PR #21 body, Privacy and threat decisions): *"`declined` and `removed` are **terminal** in this phase. Re-request windows need rate limiting and abuse review that are out of scope; terminal is the fail-closed choice."* — implemented as an unconditional early return in `request_connection`, so any request against an existing relationship was a no-op.
- **Its acceptance checklist** (PR #21 body, step 12): *"Re-open, re-request, accept, then Block."*

Step 12 cannot succeed against that state machine. The connection is removed at step 11, and every later request converges on the same canonical pair document and returns the existing `removed` record without ever reaching `pending`. There is no accept to perform and no path to the block the checklist then asks for.

**This PR reconciles the contradiction in the lifecycle, not in the checklist.** Rewriting the checklist to hide it would have shipped a lifecycle nobody can exercise and a phase that can never be accepted.


## Release status

| Item | Status |
| --- | --- |
| Required check `frontend (18.x)` | ✅ success — 33 tests passed, 51 modules built |
| Required check `python` | ✅ success — 192 passed, 9 skipped |
| Required check `legacy-node-backend (install only) (18.x)` | ✅ success |
| Vercel Preview | ✅ Ready — [preview URL](https://sportbeacon-ai-git-fix-phase-3b-con-ebf8f5-trondurells-projects.vercel.app) (returns HTTP 200) |
| Vercel Production | not promoted, unchanged |
| Staging Cloud Run | **deployed** — revision `sportbeacon-api-staging-00005-hab`; source SHA `d63bf872285b819ffb3d6b28506ebe6c553a3d00`; Cloud Build `20b863fa-f334-46bd-bf20-f9f01044af91`; image `sha256:b37933e30cc3a100842230e8feb38c345104f98bab201bded29b5cc321ad7e83`; traffic **100%** to `00005-hab`; `ENABLE_ATHLETE_CONNECTIONS=true`. Candidate probes **41/41**; post-traffic-shift probes **32/32**. Rollback target: `sportbeacon-api-staging-00004-fcw`. Staging API: `https://sportbeacon-api-staging-104921686559.us-east1.run.app` |
| Production Cloud Run | unchanged, still health-only |
| Two-account acceptance | **PASSED — operator-attested on August 22, 2026** |
| Merge | ready for guarded squash merge |

## The correction

The safety property that made terminal states attractive is preserved by a different gate: **an athlete cannot ask again because they want to. They can ask again only because the two of them actually played together again.** Shared play is scarce, physical, and mutual, so it is far harder to manufacture than a cooling-off timer — and it needs no rate-limit infrastructure, which stays out of scope here as instructed.

### Corrected state transitions

| From | To | Trigger | Who |
| --- | --- | --- | --- |
| *(none)* | `pending` | request on a run both athletes played | either athlete |
| `pending` | `accepted` | accept | recipient only |
| `pending` | `declined` | decline | recipient only |
| `pending` | `blocked` | block | either member |
| `accepted` | `removed` | remove | either member |
| `accepted` | `blocked` | block | either member |
| `declined` | `pending` | request on **later verified shared play** | either athlete |
| `removed` | `pending` | request on **later verified shared play** | either athlete |
| `declined` / `removed` | `blocked` | block | either member |
| `blocked` | — | nothing. Permanently terminal in this phase; there is no unblock endpoint | — |

### Exact definition of "later verified shared play"

A request against a `declined` or `removed` relationship reopens it only when **all** of the following hold. Any single failure returns the same uniform `That athlete is not available to connect from this run` refusal as every other unreachable outcome, so nothing new can be probed.

1. **A different run.** The `runId` is not the relationship's current `qualifyingRunId`. The run that produced the previous cycle can never reopen it.
2. **Both athletes hold eligible participation** — `checked_in` or `completed` — on that run. `going` is intent, not proof of play, and is rejected here exactly as everywhere else in this phase.
3. **Both participation records carry server check-in evidence newer than the ending.** Each side's `checkedInAt` must be **strictly** later than the relationship's `declinedAt` or `removedAt`. A `completed` record with no check-in stamp proves nothing about *when* the athletes played and does not qualify.
4. **Both athletes are mutually visible on that run** — the caller is not `hidden` and the target is discoverable.
5. **The target currently chose `open_to_connect`** on that run, re-read at request time rather than trusted from a client snapshot.
6. **Neither athlete blocked the other.** `blocked` is checked first and is terminal.

Why each part holds up:

- **`checkedInAt` is server-authoritative.** It is stamped from the server clock inside the check-in transaction, and `POST /api/runs/{runId}/check-in` accepts no body at all — there is no field for a client to send and nothing for a client to alter.
- **Check-in is stamped once.** Re-posting a check-in on a run an athlete already played is idempotent and does not refresh the stamp, so an old run cannot be replayed into newer evidence.
- **Strictly later, not "at least as late".** A check-in recorded in the same instant the connection ended is not later play.
- **A previous run cannot be reused.** A different run id still fails rule 3 when the pair played it before the ending.

Both directions are enforced in one transaction on the canonical pair document, and the same predicate drives the `canRequest` flag, so the UI can never offer an action the server would refuse.

## Data integrity

Everything PR #21 established is preserved: the canonical one-way `pairKey`, one Firestore document per unordered athlete pair, the existing opaque client-facing `connectionId`, environment-scoped paths, server-only member UIDs, deny-all client Firestore access (`firestore.rules` unchanged), and transactional concurrency protection.

Reopening **rewrites** the one canonical document — it never creates a second. `pairKey`, `members`, `connectionId`, and `createdAt` all survive a new cycle, so an athlete's opaque handle stays stable. Four additive audit fields were added, the minimum needed to represent multiple cycles safely:

| Field | Meaning |
| --- | --- |
| `requestCycle` | How many request cycles this pair has had. Starts at `1`, increments on each reopen. |
| `lastRequestedAt` | When the current cycle's request was made. |
| `previousStatus` | The state the current cycle reopened from: `declined` or `removed`, **never** `blocked` (model-validated). |
| `previousStatusAt` | When that previous cycle ended — the boundary the new evidence had to beat. |

A reopen also moves `qualifyingRunId`/`qualifyingPlaceId` to the new run's evidence, rewrites `requesterUid`/`recipientUid` so the roles describe **this** request (a reversed reconnection is a genuine new request, not a revived old one), and clears `acceptedAt`/`declinedAt`/`removedAt`. Because roles are the only identity-bearing fields a reopen rewrites, the record is re-validated before persisting, so a rewrite can never leave members and pair key disagreeing.

### Migration and compatibility

**No migration runs and no document is rewritten until a pair actually reopens.** All four fields are optional with defaults, so a document written before reconnection existed deserializes as an untouched first cycle (`requestCycle` `1`, the rest absent). A stored `declined`/`removed` document that predates the `declinedAt`/`removedAt` markers falls back to `updatedAt` as the boundary, so an absent marker still yields a real server timestamp rather than an empty boundary anything could clear. Covered by both an in-memory test and a Firestore emulator test that writes a Phase 3B-shaped document, loads it, and reopens it.

## Frontend

The panel states the server's decision rather than guessing at it. A declined or removed co-player is offered a **Reconnect** action only when the server already set `canRequest`, and the card then explains that playing this run together after the last ending is what earned the new request. Until then the card says the two need a later run they both check into — so **same-run reconnection never appears available**, and removal never claims the athletes can reconnect immediately.

Removal and blocking are now described as different things wherever either is offered: removal ends the connection and needs a later shared run before anyone can ask again; blocking is permanent and cannot be undone.

No contact details, public search, roster, messaging, notification, or follower behavior was added. Existing accessibility (`aria-live` status regions, per-athlete `aria-label`s on every action), mobile tap targets, privacy explanations, and all Phase 3A behavior are unchanged.

## Acceptance fixtures

Reconnection needs a *later* run both athletes checked into, and the labeled fixture set previously had **exactly one** run with an open check-in window — so the sequence could not be walked end to end without hand-editing Firestore. Two further labeled TEST DATA runs at the same test place now open alongside it, staggered so they list in session order:

- `test-run-basketball-active-second` — *TEST DATA — Second pickup run (later session)*
- `test-run-basketball-active-third` — *TEST DATA — Third pickup run (latest session)*

They are ordinary fixture runs: **no synthetic athlete account is created, nobody is auto-joined, nothing auto-accepts**, consent still starts `hidden` on each, and fixtures still never load in production.

## Corrected two-account acceptance checklist

**PASSED — operator-attested on August 22, 2026.** The operator completed this live two-account flow on the Preview URL against staging revision `sportbeacon-api-staging-00005-hab`. This agent did not personally perform the two-browser session. The checklist below is the sequence that passed.

1. Account A and Account B each join and check into **Run 1** (`TEST DATA — Lunch pickup run`).
2. Both choose `open_to_connect` on Run 1. Each sees only the other's display name — no email, phone number, location, or home area.
3. A sends a request to B. B sees it under Incoming requests and accepts.
4. Both refresh, navigate away to Play, and return: the connection is still under Connected athletes.
5. A removes the connection. It disappears for both, and the panel states that a new request needs a later run they both check into.
6. **On Run 1, neither account can reconnect.** The co-player card offers no Connect or Reconnect action and explains the later-run requirement; a replayed request against Run 1 is refused.
7. Both join and check into **Run 2** (`TEST DATA — Second pickup run (later session)`).
8. Both choose `open_to_connect` on Run 2.
9. The card now offers **Reconnect** and explains that playing this run together after the last ending is what allows it. Either account may send it; B accepts.
10. B blocks A.
11. **On Run 2 and on Run 3** (`TEST DATA — Third pickup run (latest session)`), neither account can rediscover or reconnect with the other, in either direction, no matter how many further runs they both check into. There is no unblock control anywhere in the UI.
12. Safety reporting still works from both a connection card and a co-player card, returns only `Report received. Our safety team reviews reports privately.`, and exposes no way to read a report back.
13. Production stays health-only, IAM is unchanged, and a direct browser Firestore read of `environments/staging/athleteConnections` still returns 401/403.

## Tests and exact results

| Suite | Result | Accepted baseline |
| --- | --- | --- |
| Frontend (`npm test`) | **33 passed** (2 files) | 30 passed |
| Frontend type-check (`tsc --noEmit`) | clean | clean |
| Frontend lint (`eslint .`) | clean | clean |
| Frontend build (`vite build`) | built, 51 modules | built, 51 modules |
| Python (`pytest -q`) | **192 passed, 9 skipped** | 177 passed, 8 skipped |
| Emulator (`pytest tests/test_firestore_emulator.py`) | **9 passed** | 8 passed |
| Legacy Node (`npm ci` in `backend/`) | install clean | install clean |
| Secret scan | no matches | no matches |

CI reproduced the frontend and Python numbers exactly on Node 18.x / Python 3.11: `192 passed, 9 skipped` and `33 passed` / `51 modules transformed`.

No existing test was deleted, skipped, or weakened. The single extra skip is the new emulator-gated test, which passes when the emulator runs (9 passed above). One existing test was renamed only: `..._decline_is_terminal` → `..._the_same_run_cannot_retry`, because it asserts same-run behavior, which is unchanged.

**Both directions of the new gate are mutation-tested.** Forcing the gate closed (restoring PR #21's terminal behavior) fails 7 of the new tests; removing the later-run and timestamp checks entirely fails 6 tests including 3 pre-existing ones. Neither an over-strict nor an over-permissive gate can pass.

New coverage: declined and removed refused on the same run; refused on a run played *before* the ending; refused when either side lacks a server check-in stamp; refused when the check-in is simultaneous with the ending rather than later; refused when a replayed check-in fails to re-stamp; refused while either athlete is only `going`; refused while the target is not `open_to_connect`; allowed on genuinely later shared play from **either** direction with roles reflecting the new request; duplicate and concurrent reversed later-run requests staying one cycle and one pending relationship; pair document and opaque connection id stable across cycles; every audit field; blocked never reopening on any later run in either direction; a declined pair still blockable before it reopens; a stored document with no audit fields loading and reopening; and no private or server-only material (`requestCycle`, `lastRequestedAt`, `previousStatus`, `previousStatusAt`, UIDs, emails, display names) reaching responses or logs. Production routes staying closed, Phase 2B, Phase 3A, insights, drills, and the rest of the Phase 3B matrix are all still covered and green.


## Deployment and safety

**Staging is deployed; production is not.** Vercel Preview is the branch-scoped artifact under acceptance and was not redeployed. Vercel Production was not promoted and still requires explicit promotion. Cloud Run staging revision `sportbeacon-api-staging-00005-hab` was built from source SHA `d63bf872285b819ffb3d6b28506ebe6c553a3d00` (Cloud Build `20b863fa-f334-46bd-bf20-f9f01044af91`, image `sha256:b37933e30cc3a100842230e8feb38c345104f98bab201bded29b5cc321ad7e83`) and now serves **100%** of staging traffic with `ENABLE_ATHLETE_CONNECTIONS=true`. Candidate probes passed **41/41** before the traffic shift; canonical staging probes passed **32/32** after. The explicit CORS allowlist includes Vercel Production and the PR #22 Preview origin. Production Cloud Run is unchanged and still health-only. No production configuration, IAM, Firebase rules, service account, key, secret, or billing setting was touched, and no cloud credential was requested or printed. The changed-file list contains no `deploy/`, `firestore.rules`, `.github/`, `vercel.json`, `firebase.json`, `.firebaserc`, or dependency file.

**Rollback:** restore 100% staging traffic to `sportbeacon-api-staging-00004-fcw`, or set `ENABLE_ATHLETE_CONNECTIONS=false` and every connection path returns to 404 immediately. No destructive migration was performed — the audit fields are additive with defaults, so reverting simply leaves reopened relationships as ordinary pending/accepted records.


## Remaining risks

- **No rate limiting.** Reconnection is bounded by later verified shared play rather than a quota. Two athletes who keep playing the same runs can cycle decline → later run → request repeatedly.
- **Blocking is permanent** in this phase; there is no unblock endpoint.
- **Only the immediately previous connection cycle is retained**, not the full history. Full cycle history belongs with the moderation surface, which is still a separate authorized phase.
- **Reports have no application read path.** Safety reports remain write-only.
- **No notification channel.**
- Display names remain athlete-controlled and unverified. `list_run_participants` still reads up to 200 participants per co-player request.

Corrected Phase 3B two-account acceptance passed. Ready for guarded squash merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02abf-586c-7c8f-a33d-49399200962a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02abf-586c-7c8f-a33d-49399200962a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

